### PR TITLE
Phase 0 Foundation: test/CI harness, EventLog spine, pure-logic extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run tests (headless)
+        run: pytest -q

--- a/dfyb/__init__.py
+++ b/dfyb/__init__.py
@@ -1,0 +1,1 @@
+"""Don't Forget Your Breaks — application package."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8,<9
+pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Runtime dependencies
+customtkinter==5.2.2

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,2 @@
+def test_dfyb_package_imports():
+    import dfyb  # noqa: F401


### PR DESCRIPTION
## Summary

First executable slice of the **Phase 0 — Activity Core** milestone (see `docs/specs/2026-06-11-roadmap-design.md` and `docs/plans/2026-06-11-phase-0-foundation.md`). Establishes the testing/CI foundation, the event-log spine, and the safe pure-logic extractions out of `launch.py` — all behavior-preserving.

- **Tooling:** new `dfyb/` package, `requirements.txt` / `requirements-dev.txt`, `pyproject.toml` pytest config, and GitHub Actions CI running headless `pytest` on push/PR.
- **EventLog spine** (`dfyb/activity/event_log.py`): append-only JSON Lines store with injectable clock — the shared core that Phase 1 (scheduler) and Phase 3 (insights) will build on.
- **Pure-logic extraction:** `dfyb/version.py` (`parse_version`, `is_newer_version`) and `dfyb/breaks/duration.py` (`to_seconds`), with `launch.py` rewired to import them. The Tk-bound `BreakConfig` now delegates its arithmetic to the pure, testable `to_seconds`.
- **Docs:** README now documents the `customtkinter` dependency and the `pip install -r requirements.txt` step.

16 unit tests, all green locally and in CI. `launch.py` still launches unchanged (behavior-preserving).

## Test Plan

- [x] `pytest -q` passes locally (16 passed)
- [x] CI green on the branch
- [x] App still launches with no traceback (`python launch.py`)
- [x] No `customtkinter`/`tkinter` imports leaked into the pure `dfyb` modules (headless-safe)

## Deferred to Phase 0b (follow-up)

- Modularize the Tk classes (`CountdownPopup`, `BreakConfigPanel`, `BreakApp` → `dfyb/ui/`); extract `sound/`, `updater/`, `persistence/`.
- Verify the PyInstaller build still bundles the new `dfyb` package (add to `hiddenimports` only if a build shows it's needed).
- #2 focus-bug verification + regression coverage.
- Event-log hardening flags from review: corrupt-line guard in `read()`, `threading.Lock` once a background sensor thread appends, single-pass `count()`.

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)