### PR TITLE
Phase 0 Foundation (rest): version/duration extraction, EventLog spine, README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A cross-platform desktop application that reminds you to take regular breaks dur
 
 - Python 3.x
 - Tkinter (included with Python on most systems)
+- [`customtkinter`](https://customtkinter.tomschimansky.com/) — installed via `requirements.txt`
 
 ### Platform Support
 
@@ -39,7 +40,12 @@ A cross-platform desktop application that reminds you to take regular breaks dur
    cd dont-forget-your-breaks
    ```
 
-2. Run the application:
+2. Install dependencies (includes `customtkinter`):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the application:
    ```bash
    python launch.py
    ```

--- a/dfyb/activity/__init__.py
+++ b/dfyb/activity/__init__.py
@@ -1,0 +1,1 @@
+"""Activity Core — sensors and the event log."""

--- a/dfyb/activity/event_log.py
+++ b/dfyb/activity/event_log.py
@@ -1,0 +1,50 @@
+"""Append-only, persisted activity/break event log (JSON Lines).
+
+The shared spine of the app: the scheduler (Phase 1) reads it to decide when
+to nudge, and insights (Phase 3) read it to build dashboards. Pass a custom
+`clock` for deterministic tests.
+"""
+import json
+import time
+from pathlib import Path
+
+# Event type constants (extended as later phases need them).
+BREAK_DUE = "break_due"
+BREAK_TAKEN = "break_taken"
+BREAK_SKIPPED = "break_skipped"
+BREAK_SNOOZED = "break_snoozed"
+IDLE_DETECTED = "idle_detected"
+
+
+class EventLog:
+    """Append-only JSON Lines event store."""
+
+    def __init__(self, path, clock=time.time):
+        self.path = Path(path)
+        self._clock = clock
+
+    def append(self, event_type, **data):
+        """Append an event and return it. Each event: {ts, type, data}."""
+        event = {"ts": self._clock(), "type": event_type, "data": data}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event) + "\n")
+        return event
+
+    def read(self):
+        """Return all events as a list of dicts (empty if the file is absent)."""
+        if not self.path.exists():
+            return []
+        events = []
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    events.append(json.loads(line))
+        return events
+
+    def count(self, event_type=None):
+        """Count all events, or only those of `event_type`."""
+        if event_type is None:
+            return len(self.read())
+        return sum(1 for e in self.read() if e["type"] == event_type)

--- a/dfyb/breaks/__init__.py
+++ b/dfyb/breaks/__init__.py
@@ -1,0 +1,1 @@
+"""Break domain logic."""

--- a/dfyb/breaks/duration.py
+++ b/dfyb/breaks/duration.py
@@ -1,0 +1,14 @@
+"""Pure time-unit conversion (no Tk)."""
+
+
+def to_seconds(value, unit):
+    """Convert an integer value + unit ('sec'/'min'/'hour') to seconds.
+
+    Any unit other than 'sec'/'min' is treated as hours, preserving the
+    original behavior in launch.py.
+    """
+    if unit == "sec":
+        return value
+    if unit == "min":
+        return value * 60
+    return value * 3600

--- a/dfyb/version.py
+++ b/dfyb/version.py
@@ -1,0 +1,14 @@
+"""Pure version-string helpers (no Tk, no I/O)."""
+
+
+def parse_version(version_str):
+    """Parse a version string like '1.0.3' into a tuple of ints for comparison."""
+    try:
+        return tuple(int(x) for x in version_str.lstrip('v').split('.'))
+    except (ValueError, AttributeError):
+        return (0, 0, 0)
+
+
+def is_newer_version(latest, current):
+    """Return True if latest version is newer than current."""
+    return parse_version(latest) > parse_version(current)

--- a/launch.py
+++ b/launch.py
@@ -13,6 +13,7 @@ import platform
 from urllib.parse import quote as url_quote
 import logging
 from pathlib import Path
+from dfyb.version import parse_version, is_newer_version
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -180,13 +181,6 @@ def get_current_version():
         return "0.0.0"
 
 
-def parse_version(version_str):
-    """Parse a version string like '1.0.3' into a tuple of ints for comparison."""
-    try:
-        return tuple(int(x) for x in version_str.lstrip('v').split('.'))
-    except (ValueError, AttributeError):
-        return (0, 0, 0)
-
 
 def fetch_latest_version():
     """Query GitHub releases API for the latest version. Returns (version, url) or None."""
@@ -205,10 +199,6 @@ def fetch_latest_version():
     except Exception:
         return None
 
-
-def is_newer_version(latest, current):
-    """Return True if latest version is newer than current."""
-    return parse_version(latest) > parse_version(current)
 
 
 def is_installed_via_homebrew():

--- a/launch.py
+++ b/launch.py
@@ -14,6 +14,7 @@ from urllib.parse import quote as url_quote
 import logging
 from pathlib import Path
 from dfyb.version import parse_version, is_newer_version
+from dfyb.breaks.duration import to_seconds
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -269,25 +270,11 @@ class BreakConfig:
 
     def get_interval_seconds(self):
         """Convert interval to seconds."""
-        val = self._safe_int(self.interval_value)
-        unit = self.interval_unit.get()
-        if unit == "sec":
-            return val
-        elif unit == "min":
-            return val * 60
-        else:  # hour
-            return val * 3600
+        return to_seconds(self._safe_int(self.interval_value), self.interval_unit.get())
 
     def get_duration_seconds(self):
         """Convert duration to seconds."""
-        val = self._safe_int(self.duration_value)
-        unit = self.duration_unit.get()
-        if unit == "sec":
-            return val
-        elif unit == "min":
-            return val * 60
-        else:  # hour
-            return val * 3600
+        return to_seconds(self._safe_int(self.duration_value), self.duration_unit.get())
 
     def reset_timer(self):
         """Reset remaining time to interval."""

--- a/tests/test_duration.py
+++ b/tests/test_duration.py
@@ -1,0 +1,18 @@
+from dfyb.breaks.duration import to_seconds
+
+
+def test_seconds_pass_through():
+    assert to_seconds(45, "sec") == 45
+
+
+def test_minutes_to_seconds():
+    assert to_seconds(25, "min") == 25 * 60
+
+
+def test_hours_to_seconds():
+    assert to_seconds(2, "hour") == 2 * 3600
+
+
+def test_unknown_unit_matches_legacy_hour_behavior():
+    # Legacy code's final `else` branch multiplied by 3600 for any non-sec/min unit.
+    assert to_seconds(1, "fortnight") == 3600

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -1,0 +1,49 @@
+from dfyb.activity.event_log import EventLog, BREAK_TAKEN, BREAK_SKIPPED
+
+
+class FakeClock:
+    """Deterministic monotonically-increasing clock for tests."""
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        self.t += 1
+        return self.t
+
+
+def test_append_returns_event(tmp_path):
+    log = EventLog(tmp_path / "events.jsonl", clock=FakeClock())
+    event = log.append(BREAK_TAKEN, break_name="Micro Break")
+    assert event["type"] == BREAK_TAKEN
+    assert event["data"] == {"break_name": "Micro Break"}
+    assert event["ts"] == 1001.0
+
+
+def test_read_empty_when_no_file(tmp_path):
+    log = EventLog(tmp_path / "missing.jsonl")
+    assert log.read() == []
+
+
+def test_append_then_read_roundtrip(tmp_path):
+    log = EventLog(tmp_path / "events.jsonl", clock=FakeClock())
+    log.append(BREAK_TAKEN, break_name="A")
+    log.append(BREAK_SKIPPED, break_name="B")
+    events = log.read()
+    assert [e["type"] for e in events] == [BREAK_TAKEN, BREAK_SKIPPED]
+    assert events[1]["data"]["break_name"] == "B"
+
+
+def test_persists_across_instances(tmp_path):
+    path = tmp_path / "events.jsonl"
+    EventLog(path, clock=FakeClock()).append(BREAK_TAKEN)
+    reopened = EventLog(path)
+    assert reopened.count() == 1
+
+
+def test_count_by_type(tmp_path):
+    log = EventLog(tmp_path / "events.jsonl", clock=FakeClock())
+    log.append(BREAK_TAKEN)
+    log.append(BREAK_TAKEN)
+    log.append(BREAK_SKIPPED)
+    assert log.count(BREAK_TAKEN) == 2
+    assert log.count() == 3

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+from dfyb.version import parse_version, is_newer_version
+
+
+def test_parse_basic():
+    assert parse_version("1.2.3") == (1, 2, 3)
+
+
+def test_parse_strips_leading_v():
+    assert parse_version("v1.0.13") == (1, 0, 13)
+
+
+def test_parse_invalid_returns_zeros():
+    assert parse_version("not-a-version") == (0, 0, 0)
+    assert parse_version(None) == (0, 0, 0)
+
+
+def test_is_newer_true():
+    assert is_newer_version("1.0.13", "1.0.12") is True
+
+
+def test_is_newer_false_when_equal():
+    assert is_newer_version("1.0.13", "1.0.13") is False
+
+
+def test_is_newer_false_when_older():
+    assert is_newer_version("1.0.11", "1.0.13") is False


### PR DESCRIPTION
## Summary

Completes the Phase 0 foundation. **PR #16 only merged Tasks 1–2** (scaffolding + CI) because these commits were not pushed before that PR was created. This PR adds the remaining four tasks:

- `dfyb/version.py` — pure `parse_version` / `is_newer_version` (extracted from `launch.py`, with tests).
- `dfyb/breaks/duration.py` — pure `to_seconds`; `BreakConfig` now delegates its arithmetic to it.
- `dfyb/activity/event_log.py` — the append-only JSON Lines **EventLog spine** (injectable clock), the shared core for Phase 1 (scheduler) and Phase 3 (insights).
- README now documents the `customtkinter` dependency and `pip install` step.

`launch.py` is rewired to import the extracted helpers and still launches unchanged (behavior-preserving).

## Test Plan

- [ ] CI green (should now collect **16** tests, not 1)
- [ ] `launch.py` launches with no traceback
- [ ] No `customtkinter`/`tkinter` imports in the pure `dfyb` modules

Genuinely closes #15 (the README fix lives in this PR, not #16).