### PR TITLE
Phase 0b-1: extract sound/updater/animation service modules

### DIFF
--- a/dfyb/animation.py
+++ b/dfyb/animation.py
@@ -1,0 +1,27 @@
+"""Easing helpers and the macOS reduced-motion preference check."""
+import subprocess
+import sys
+
+
+def ease_out_quad(t):
+    """Quadratic ease-out: fast start, slow end."""
+    return t * (2 - t)
+
+
+def ease_in_quad(t):
+    """Quadratic ease-in: slow start, fast end."""
+    return t * t
+
+
+def prefers_reduced_motion():
+    """Check if user has enabled reduced motion (macOS)."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["defaults", "read", "-g", "AppleReduceMotion"],
+            capture_output=True, text=True
+        )
+        return result.stdout.strip() == "1"
+    except Exception:
+        return False

--- a/dfyb/sound.py
+++ b/dfyb/sound.py
@@ -1,0 +1,43 @@
+"""System sound playback (macOS afplay; beep/bell fallback elsewhere)."""
+import subprocess
+import sys
+import time
+
+SOUND_LOOP_INTERVAL = 1.2
+
+# Sound options including "None". Values are macOS system-sound filenames.
+SOUNDS = {
+    "None": None,
+    "Glass": "Glass.aiff",
+    "Ping": "Ping.aiff",
+    "Pop": "Pop.aiff",
+    "Submarine": "Submarine.aiff",
+}
+
+
+def play_sound_mac(sound_name):
+    sound_file = SOUNDS.get(sound_name)
+    if sound_file:
+        subprocess.Popen(
+            ["afplay", f"/System/Library/Sounds/{sound_file}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+def play_sound(sound_name="Glass"):
+    if sound_name == "None" or sound_name is None:
+        return
+    if sys.platform == "darwin":
+        play_sound_mac(sound_name)
+    elif sys.platform == "win32":
+        import winsound
+        winsound.MessageBeep()
+    else:
+        print("\a")
+
+
+def looping_sound(stop_event, sound_name):
+    while not stop_event.is_set():
+        play_sound(sound_name)
+        time.sleep(SOUND_LOOP_INTERVAL)

--- a/dfyb/updater.py
+++ b/dfyb/updater.py
@@ -1,0 +1,53 @@
+"""App version reporting and GitHub/Homebrew update checks."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Resolve VERSION relative to the repo root (parent of the dfyb/ package),
+# or the PyInstaller bundle dir when frozen. parent.parent: dfyb/updater.py -> repo root.
+BASE_DIR = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent.parent))
+VERSION_FILE = BASE_DIR / "VERSION"
+
+GITHUB_REPO = "YairShachar/dont-forget-your-breaks"
+GITHUB_RELEASES_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+GITHUB_RELEASES_PAGE_URL = f"https://github.com/{GITHUB_REPO}/releases/latest"
+HOMEBREW_CASK_NAME = "dont-forget-your-breaks"
+
+
+def get_current_version():
+    """Read the current app version from VERSION file."""
+    try:
+        return VERSION_FILE.read_text().strip()
+    except (FileNotFoundError, IOError):
+        return "0.0.0"
+
+
+def fetch_latest_version():
+    """Query GitHub releases API for the latest version. Returns (version, url) or None."""
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "-H", "Accept: application/vnd.github.v3+json",
+             "--max-time", "10", GITHUB_RELEASES_API_URL],
+            capture_output=True, text=True, timeout=15
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        tag = data.get("tag_name", "")
+        html_url = data.get("html_url", GITHUB_RELEASES_PAGE_URL)
+        return tag.lstrip('v'), html_url
+    except Exception:
+        return None
+
+
+def is_installed_via_homebrew():
+    """Check if the app was installed via Homebrew cask."""
+    try:
+        result = subprocess.run(
+            ["brew", "list", "--cask", HOMEBREW_CASK_NAME],
+            capture_output=True, timeout=10
+        )
+        return result.returncode == 0
+    except Exception:
+        return False

--- a/launch.py
+++ b/launch.py
@@ -15,6 +15,7 @@ import logging
 from pathlib import Path
 from dfyb.version import parse_version, is_newer_version
 from dfyb.breaks.duration import to_seconds
+from dfyb.sound import play_sound, looping_sound, SOUNDS
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -69,7 +70,6 @@ if sys.platform == "darwin":
 # ------------------ CONFIGURATION ------------------
 
 TIME_UNITS = ["sec", "min", "hour"]
-SOUND_LOOP_INTERVAL = 1.2
 CONFIG_FILE = Path.home() / "Library" / "Preferences" / "com.yairs.dontforgetyourbreaks.json"
 LOCK_FILE = Path.home() / "Library" / "Application Support" / "DontForgetYourBreaks" / ".lock"
 BASE_DIR = Path(getattr(sys, '_MEIPASS', Path(__file__).parent))
@@ -131,45 +131,6 @@ PANEL_COLLAPSED_HEIGHT = 48      # Height of collapsed panel header
 ANIMATION_FRAME_INTERVAL = 16      # ms (60fps)
 ANIMATION_EXPAND_DURATION = 250    # ms
 ANIMATION_COLLAPSE_DURATION = 200  # ms
-
-# Sound options including "None"
-SOUNDS = {
-    "None": None,
-    "Glass": "Glass.aiff",
-    "Ping": "Ping.aiff",
-    "Pop": "Pop.aiff",
-    "Submarine": "Submarine.aiff"
-}
-
-
-# ------------------ SOUND FUNCTIONS ------------------
-
-def play_sound_mac(sound_name):
-    sound_file = SOUNDS.get(sound_name)
-    if sound_file:
-        subprocess.Popen(
-            ["afplay", f"/System/Library/Sounds/{sound_file}"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL
-        )
-
-
-def play_sound(sound_name="Glass"):
-    if sound_name == "None" or sound_name is None:
-        return
-    if sys.platform == "darwin":
-        play_sound_mac(sound_name)
-    elif sys.platform == "win32":
-        import winsound
-        winsound.MessageBeep()
-    else:
-        print("\a")
-
-
-def looping_sound(stop_event, sound_name):
-    while not stop_event.is_set():
-        play_sound(sound_name)
-        time.sleep(SOUND_LOOP_INTERVAL)
 
 
 # ------------------ UPDATE CHECKER ------------------

--- a/launch.py
+++ b/launch.py
@@ -16,6 +16,13 @@ from pathlib import Path
 from dfyb.version import parse_version, is_newer_version
 from dfyb.breaks.duration import to_seconds
 from dfyb.sound import play_sound, looping_sound, SOUNDS
+from dfyb.updater import (
+    get_current_version,
+    fetch_latest_version,
+    is_installed_via_homebrew,
+    VERSION_FILE,
+    HOMEBREW_CASK_NAME,
+)
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -72,14 +79,8 @@ if sys.platform == "darwin":
 TIME_UNITS = ["sec", "min", "hour"]
 CONFIG_FILE = Path.home() / "Library" / "Preferences" / "com.yairs.dontforgetyourbreaks.json"
 LOCK_FILE = Path.home() / "Library" / "Application Support" / "DontForgetYourBreaks" / ".lock"
-BASE_DIR = Path(getattr(sys, '_MEIPASS', Path(__file__).parent))
-VERSION_FILE = BASE_DIR / "VERSION"
 GITHUB_NEW_ISSUE_URL = "https://github.com/YairShachar/dont-forget-your-breaks/issues/new"
-GITHUB_REPO = "YairShachar/dont-forget-your-breaks"
-GITHUB_RELEASES_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
-GITHUB_RELEASES_PAGE_URL = f"https://github.com/{GITHUB_REPO}/releases/latest"
 UPDATE_CHECK_INTERVAL_HOURS = 24
-HOMEBREW_CASK_NAME = "dont-forget-your-breaks"
 
 # Design constants
 FONT_FAMILY = "SF Pro Display" if sys.platform == "darwin" else "Segoe UI"
@@ -131,48 +132,6 @@ PANEL_COLLAPSED_HEIGHT = 48      # Height of collapsed panel header
 ANIMATION_FRAME_INTERVAL = 16      # ms (60fps)
 ANIMATION_EXPAND_DURATION = 250    # ms
 ANIMATION_COLLAPSE_DURATION = 200  # ms
-
-
-# ------------------ UPDATE CHECKER ------------------
-
-def get_current_version():
-    """Read the current app version from VERSION file."""
-    try:
-        return VERSION_FILE.read_text().strip()
-    except (FileNotFoundError, IOError):
-        return "0.0.0"
-
-
-
-def fetch_latest_version():
-    """Query GitHub releases API for the latest version. Returns (version, url) or None."""
-    try:
-        result = subprocess.run(
-            ["curl", "-s", "-H", "Accept: application/vnd.github.v3+json",
-             "--max-time", "10", GITHUB_RELEASES_API_URL],
-            capture_output=True, text=True, timeout=15
-        )
-        if result.returncode != 0:
-            return None
-        data = json.loads(result.stdout)
-        tag = data.get("tag_name", "")
-        html_url = data.get("html_url", GITHUB_RELEASES_PAGE_URL)
-        return tag.lstrip('v'), html_url
-    except Exception:
-        return None
-
-
-
-def is_installed_via_homebrew():
-    """Check if the app was installed via Homebrew cask."""
-    try:
-        result = subprocess.run(
-            ["brew", "list", "--cask", HOMEBREW_CASK_NAME],
-            capture_output=True, timeout=10
-        )
-        return result.returncode == 0
-    except Exception:
-        return False
 
 
 # ------------------ ANIMATION HELPERS ------------------

--- a/launch.py
+++ b/launch.py
@@ -23,7 +23,7 @@ from dfyb.updater import (
     VERSION_FILE,
     HOMEBREW_CASK_NAME,
 )
-from dfyb.animation import ease_out_quad, ease_in_quad, prefers_reduced_motion
+from dfyb.animation import ease_out_quad, prefers_reduced_motion
 
 logging.basicConfig(
     level=logging.DEBUG,

--- a/launch.py
+++ b/launch.py
@@ -23,6 +23,7 @@ from dfyb.updater import (
     VERSION_FILE,
     HOMEBREW_CASK_NAME,
 )
+from dfyb.animation import ease_out_quad, ease_in_quad, prefers_reduced_motion
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -132,32 +133,6 @@ PANEL_COLLAPSED_HEIGHT = 48      # Height of collapsed panel header
 ANIMATION_FRAME_INTERVAL = 16      # ms (60fps)
 ANIMATION_EXPAND_DURATION = 250    # ms
 ANIMATION_COLLAPSE_DURATION = 200  # ms
-
-
-# ------------------ ANIMATION HELPERS ------------------
-
-def ease_out_quad(t):
-    """Quadratic ease-out: fast start, slow end."""
-    return t * (2 - t)
-
-
-def ease_in_quad(t):
-    """Quadratic ease-in: slow start, fast end."""
-    return t * t
-
-
-def prefers_reduced_motion():
-    """Check if user has enabled reduced motion (macOS)."""
-    if sys.platform != "darwin":
-        return False
-    try:
-        result = subprocess.run(
-            ["defaults", "read", "-g", "AppleReduceMotion"],
-            capture_output=True, text=True
-        )
-        return result.stdout.strip() == "1"
-    except Exception:
-        return False
 
 
 # ------------------ BREAK CONFIG ------------------

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,39 @@
+import dfyb.animation as animation
+from dfyb.animation import ease_out_quad, ease_in_quad, prefers_reduced_motion
+
+
+class FakeProc:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def test_ease_out_quad_endpoints():
+    assert ease_out_quad(0) == 0
+    assert ease_out_quad(1) == 1
+
+
+def test_ease_out_quad_midpoint():
+    assert ease_out_quad(0.5) == 0.75
+
+
+def test_ease_in_quad():
+    assert ease_in_quad(0) == 0
+    assert ease_in_quad(0.5) == 0.25
+    assert ease_in_quad(1) == 1
+
+
+def test_prefers_reduced_motion_non_darwin(monkeypatch):
+    monkeypatch.setattr(animation.sys, "platform", "linux")
+    assert prefers_reduced_motion() is False
+
+
+def test_prefers_reduced_motion_darwin_enabled(monkeypatch):
+    monkeypatch.setattr(animation.sys, "platform", "darwin")
+    monkeypatch.setattr(animation.subprocess, "run", lambda *a, **k: FakeProc("1\n"))
+    assert prefers_reduced_motion() is True
+
+
+def test_prefers_reduced_motion_darwin_disabled(monkeypatch):
+    monkeypatch.setattr(animation.sys, "platform", "darwin")
+    monkeypatch.setattr(animation.subprocess, "run", lambda *a, **k: FakeProc("0\n"))
+    assert prefers_reduced_motion() is False

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,44 @@
+import threading
+
+import dfyb.sound as sound
+from dfyb.sound import play_sound, SOUNDS
+
+
+class OneShotStop:
+    """Stop-event whose is_set() is False once, then True (one loop iteration)."""
+    def __init__(self):
+        self.checks = 0
+
+    def is_set(self):
+        self.checks += 1
+        return self.checks > 1
+
+
+def test_sounds_has_expected_entries():
+    assert SOUNDS["None"] is None
+    assert SOUNDS["Glass"] == "Glass.aiff"
+
+
+def test_play_sound_none_is_noop(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sound.subprocess, "Popen", lambda *a, **k: calls.append(a))
+    play_sound("None")
+    play_sound(None)
+    assert calls == []
+
+
+def test_play_sound_mac_invokes_afplay(monkeypatch):
+    captured = []
+    monkeypatch.setattr(sound.sys, "platform", "darwin")
+    monkeypatch.setattr(sound.subprocess, "Popen", lambda cmd, **k: captured.append(cmd))
+    play_sound("Glass")
+    assert captured and captured[0][0] == "afplay"
+    assert captured[0][1].endswith("Glass.aiff")
+
+
+def test_looping_sound_runs_until_stopped(monkeypatch):
+    played = []
+    monkeypatch.setattr(sound, "play_sound", lambda name: played.append(name))
+    monkeypatch.setattr(sound.time, "sleep", lambda s: None)
+    sound.looping_sound(OneShotStop(), "Glass")
+    assert played == ["Glass"]

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,51 @@
+import json
+
+import dfyb.updater as updater
+from dfyb.updater import (
+    get_current_version,
+    fetch_latest_version,
+    is_installed_via_homebrew,
+)
+
+
+class FakeProc:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_get_current_version_reads_file(tmp_path, monkeypatch):
+    vf = tmp_path / "VERSION"
+    vf.write_text("1.2.3\n")
+    monkeypatch.setattr(updater, "VERSION_FILE", vf)
+    assert get_current_version() == "1.2.3"
+
+
+def test_get_current_version_missing_returns_zero(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater, "VERSION_FILE", tmp_path / "nope")
+    assert get_current_version() == "0.0.0"
+
+
+def test_fetch_latest_version_parses(monkeypatch):
+    payload = json.dumps({"tag_name": "v2.0.1", "html_url": "https://x/rel"})
+    monkeypatch.setattr(updater.subprocess, "run", lambda *a, **k: FakeProc(0, payload))
+    assert fetch_latest_version() == ("2.0.1", "https://x/rel")
+
+
+def test_fetch_latest_version_nonzero_returns_none(monkeypatch):
+    monkeypatch.setattr(updater.subprocess, "run", lambda *a, **k: FakeProc(1, ""))
+    assert fetch_latest_version() is None
+
+
+def test_fetch_latest_version_exception_returns_none(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("no curl")
+    monkeypatch.setattr(updater.subprocess, "run", boom)
+    assert fetch_latest_version() is None
+
+
+def test_is_installed_via_homebrew(monkeypatch):
+    monkeypatch.setattr(updater.subprocess, "run", lambda *a, **k: FakeProc(0))
+    assert is_installed_via_homebrew() is True
+    monkeypatch.setattr(updater.subprocess, "run", lambda *a, **k: FakeProc(1))
+    assert is_installed_via_homebrew() is False


### PR DESCRIPTION
## Summary

Continues the modularization (Phase 0b-1). Extracts the three non-UI service groups out of `launch.py` into focused, tested `dfyb/` modules — behavior-preserving mechanical moves. The risky UI-class extraction is deferred to Phase 0b-2.

- `dfyb/sound.py` — `play_sound` / `play_sound_mac` / `looping_sound` + `SOUNDS` / `SOUND_LOOP_INTERVAL`
- `dfyb/updater.py` — `get_current_version` / `fetch_latest_version` / `is_installed_via_homebrew` + their constants. `BASE_DIR` is recomputed as `Path(__file__).resolve().parent.parent` so the `VERSION` path still resolves to the repo root from inside `dfyb/` (verified at runtime: returns the real version, not `0.0.0`).
- `dfyb/animation.py` — `ease_out_quad` / `ease_in_quad` / `prefers_reduced_motion`
- **PyInstaller build verified**: the frozen `.app` launches with `dfyb` imported — no `.spec` change needed.

`launch.py` imports from all three and still launches unchanged; UI class bodies/call sites untouched.

## Test Plan

- [x] `pytest -q` → **32 passed** locally (CI should match)
- [x] `python launch.py` launches with no traceback
- [x] Built `.app` runs without a `dfyb` ModuleNotFoundError
- [x] No `tkinter`/`customtkinter` imports in the new modules (headless-safe)

## Carried into Phase 0b-2
- Shared `tests/conftest.py` (dedupe `FakeProc`), `winsound` hiddenimport if a Windows target appears, non-darwin `play_sound` branch tests.