### PR TITLE
Phase 1a: scheduling engine + macOS sensors (Perfect Timing brain)

### DIFF
--- a/dfyb/activity/event_log.py
+++ b/dfyb/activity/event_log.py
@@ -14,6 +14,8 @@ BREAK_TAKEN = "break_taken"
 BREAK_SKIPPED = "break_skipped"
 BREAK_SNOOZED = "break_snoozed"
 IDLE_DETECTED = "idle_detected"
+BREAK_DEFERRED = "break_deferred"
+NATURAL_BREAK = "natural_break"
 
 
 class EventLog:

--- a/dfyb/activity/sensors.py
+++ b/dfyb/activity/sensors.py
@@ -1,0 +1,59 @@
+"""macOS context sensors (idle time, fullscreen) for the scheduler.
+
+Best-effort: on non-macOS or any failure, returns safe defaults (idle=0.0,
+fullscreen=False) so the scheduler falls back to today's 'always fire' behavior.
+`Quartz` is imported lazily inside each function so this module imports cleanly
+on non-macOS CI (where Quartz is absent).
+"""
+import sys
+
+from dfyb.scheduler.engine import Context
+
+
+def idle_seconds():
+    """Seconds since the last user input event (macOS). 0.0 elsewhere / on failure."""
+    if sys.platform != "darwin":
+        return 0.0
+    try:
+        import Quartz
+        return float(Quartz.CGEventSourceSecondsSinceLastEventType(
+            Quartz.kCGEventSourceStateHIDSystemState,
+            Quartz.kCGAnyInputEventType,
+        ))
+    except Exception:
+        return 0.0
+
+
+def frontmost_is_fullscreen():
+    """Best-effort: is the frontmost on-screen window covering the full display?
+
+    False on non-macOS or any failure (fails safe — 'not fullscreen' => fire).
+    Heuristic: the first layer-0 (normal app) window in front-to-back order whose
+    bounds cover the main display is treated as fullscreen.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        import Quartz
+        display = Quartz.CGMainDisplayID()
+        screen_w = Quartz.CGDisplayPixelsWide(display)
+        screen_h = Quartz.CGDisplayPixelsHigh(display)
+        windows = Quartz.CGWindowListCopyWindowInfo(
+            Quartz.kCGWindowListOptionOnScreenOnly
+            | Quartz.kCGWindowListExcludeDesktopElements,
+            Quartz.kCGNullWindowID,
+        )
+        for window in windows:
+            if window.get("kCGWindowLayer", 1) != 0:
+                continue  # skip menu bar, dock, overlays — only normal app windows
+            bounds = window.get("kCGWindowBounds", {})
+            return (bounds.get("Width", 0) >= screen_w
+                    and bounds.get("Height", 0) >= screen_h)
+        return False
+    except Exception:
+        return False
+
+
+def read_context():
+    """Snapshot the current context for the scheduler."""
+    return Context(idle_seconds=idle_seconds(), is_fullscreen=frontmost_is_fullscreen())

--- a/dfyb/scheduler/__init__.py
+++ b/dfyb/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""Scheduling brain — the pure 'earn the interruption' decision logic."""

--- a/dfyb/scheduler/engine.py
+++ b/dfyb/scheduler/engine.py
@@ -27,7 +27,7 @@ class BreakState:
 @dataclass(frozen=True)
 class StepResult:
     """What the loop should do this tick."""
-    new_remaining: list             # updated `remaining` per break (write back to configs)
+    new_remaining: list[int]        # updated `remaining` per break (write back to configs)
     natural_break: bool = False
     fire_index: int | None = None   # which break to pop
     defer_reason: str | None = None  # "fullscreen" | "away"

--- a/dfyb/scheduler/engine.py
+++ b/dfyb/scheduler/engine.py
@@ -1,0 +1,80 @@
+"""Pure scheduling brain: decide fire/defer/natural-break from a Context. No Tk, no I/O."""
+from dataclasses import dataclass
+
+# Configurable thresholds (can surface to a settings UI in a later phase).
+NATURAL_BREAK_IDLE_THRESHOLD_SECONDS = 300  # idle >= this => natural break (reset all timers)
+AWAY_IDLE_THRESHOLD_SECONDS = 60            # idle >= this at fire time => defer (briefly away)
+
+FIRE = "fire"
+DEFER = "defer"
+
+
+@dataclass(frozen=True)
+class Context:
+    """What the sensors observed this tick."""
+    idle_seconds: float
+    is_fullscreen: bool
+
+
+@dataclass(frozen=True)
+class BreakState:
+    """Plain, Tk-free snapshot of one break, parallel to the configs."""
+    remaining: int          # seconds left on this break's countdown
+    interval_seconds: int   # reset value (BreakConfig.get_interval_seconds())
+    duration_seconds: int   # how long the break lasts (used for "longest wins")
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """What the loop should do this tick."""
+    new_remaining: list             # updated `remaining` per break (write back to configs)
+    natural_break: bool = False
+    fire_index: int | None = None   # which break to pop
+    defer_reason: str | None = None  # "fullscreen" | "away"
+
+
+def is_natural_break(idle_seconds, threshold=NATURAL_BREAK_IDLE_THRESHOLD_SECONDS):
+    """True if the user has been idle long enough to count as having taken a break."""
+    return idle_seconds >= threshold
+
+
+def decide(ctx, away_threshold=AWAY_IDLE_THRESHOLD_SECONDS):
+    """Decide whether a due break should FIRE or DEFER given the current context."""
+    if ctx.is_fullscreen:
+        return DEFER          # don't interrupt fullscreen
+    if ctx.idle_seconds >= away_threshold:
+        return DEFER          # briefly away — wait until back and active
+    return FIRE
+
+
+def step(states, ctx,
+         natural_threshold=NATURAL_BREAK_IDLE_THRESHOLD_SECONDS,
+         away_threshold=AWAY_IDLE_THRESHOLD_SECONDS):
+    """Advance one 1-second tick. Returns a StepResult describing what to do.
+
+    `states` is a list[BreakState] parallel to the app's break configs.
+    """
+    # 1. Natural break: idle long enough -> reset all timers, do not decrement.
+    if is_natural_break(ctx.idle_seconds, natural_threshold):
+        return StepResult(new_remaining=[s.interval_seconds for s in states],
+                          natural_break=True)
+
+    # 2. Decrement; collect breaks that are now due.
+    new_remaining = [s.remaining - 1 for s in states]
+    due = [i for i, r in enumerate(new_remaining) if r <= 0]
+
+    # 3. If any are due, decide fire vs defer.
+    if due:
+        if decide(ctx, away_threshold) == DEFER:
+            reason = "fullscreen" if ctx.is_fullscreen else "away"
+            for i in due:
+                new_remaining[i] = 0          # clamp — stays due, no negative drift
+            return StepResult(new_remaining=new_remaining, defer_reason=reason)
+        # FIRE: pop the longest-duration due break; reset all due breaks.
+        fire_index = max(due, key=lambda i: states[i].duration_seconds)
+        for i in due:
+            new_remaining[i] = states[i].interval_seconds
+        return StepResult(new_remaining=new_remaining, fire_index=fire_index)
+
+    # 4. Nothing due — just the decremented counters.
+    return StepResult(new_remaining=new_remaining)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 # Runtime dependencies
 customtkinter==5.2.2
+# macOS-only: idle/fullscreen sensors. The env marker keeps Linux CI from trying
+# to install it (pyobjc wheels are macOS-only).
+pyobjc-framework-Quartz; sys_platform == "darwin"

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -47,3 +47,9 @@ def test_count_by_type(tmp_path):
     log.append(BREAK_SKIPPED)
     assert log.count(BREAK_TAKEN) == 2
     assert log.count() == 3
+
+
+def test_phase1_event_constants_exist():
+    from dfyb.activity.event_log import BREAK_DEFERRED, NATURAL_BREAK
+    assert BREAK_DEFERRED == "break_deferred"
+    assert NATURAL_BREAK == "natural_break"

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -91,3 +91,10 @@ def test_step_empty_states_is_safe():
     assert r.new_remaining == []
     assert r.natural_break is False
     assert r.fire_index is None and r.defer_reason is None
+
+
+def test_step_defer_prefers_fullscreen_over_away():
+    # When both fullscreen AND away apply, fullscreen wins the defer reason.
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=120, fullscreen=True))
+    assert r.defer_reason == "fullscreen"

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -1,0 +1,85 @@
+from dfyb.scheduler.engine import (
+    Context, BreakState, step, decide, is_natural_break, FIRE, DEFER,
+)
+
+
+def ctx(idle=0.0, fullscreen=False):
+    return Context(idle_seconds=idle, is_fullscreen=fullscreen)
+
+
+def test_is_natural_break_threshold():
+    assert is_natural_break(300) is True
+    assert is_natural_break(299) is False
+    assert is_natural_break(10, threshold=5) is True
+
+
+def test_decide_fire_when_active():
+    assert decide(ctx(idle=0, fullscreen=False)) == FIRE
+
+
+def test_decide_defer_when_fullscreen():
+    assert decide(ctx(idle=0, fullscreen=True)) == DEFER
+
+
+def test_decide_defer_when_away():
+    assert decide(ctx(idle=120, fullscreen=False)) == DEFER
+
+
+def test_step_natural_break_resets_all():
+    states = [BreakState(remaining=5, interval_seconds=100, duration_seconds=5),
+              BreakState(remaining=8, interval_seconds=200, duration_seconds=600)]
+    r = step(states, ctx(idle=300))
+    assert r.natural_break is True
+    assert r.new_remaining == [100, 200]
+    assert r.fire_index is None and r.defer_reason is None
+
+
+def test_step_decrements_when_not_due():
+    states = [BreakState(remaining=5, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=0))
+    assert r.new_remaining == [4]
+    assert r.natural_break is False and r.fire_index is None and r.defer_reason is None
+
+
+def test_step_fires_when_due_and_active():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=0))
+    assert r.fire_index == 0
+    assert r.new_remaining == [100]  # reset to interval
+
+
+def test_step_fire_picks_longest_duration():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5),
+              BreakState(remaining=1, interval_seconds=200, duration_seconds=600)]
+    r = step(states, ctx(idle=0))
+    assert r.fire_index == 1               # longer duration wins
+    assert r.new_remaining == [100, 200]   # both due breaks reset
+
+
+def test_step_defers_on_fullscreen_and_clamps():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=0, fullscreen=True))
+    assert r.defer_reason == "fullscreen"
+    assert r.fire_index is None
+    assert r.new_remaining == [0]          # clamped, stays due
+
+
+def test_step_defers_when_away_and_clamps():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=120, fullscreen=False))
+    assert r.defer_reason == "away"
+    assert r.new_remaining == [0]
+
+
+def test_step_deferred_break_stays_due_next_tick():
+    states = [BreakState(remaining=0, interval_seconds=100, duration_seconds=5)]
+    r = step(states, ctx(idle=0, fullscreen=True))
+    assert r.defer_reason == "fullscreen"
+    assert r.new_remaining == [0]          # -1 then clamped back to 0
+
+
+def test_step_thresholds_are_parameterizable():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    # idle 10 with away_threshold 5 -> defer; natural_threshold high so not natural
+    r = step(states, ctx(idle=10), natural_threshold=300, away_threshold=5)
+    assert r.defer_reason == "away"

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -83,3 +83,11 @@ def test_step_thresholds_are_parameterizable():
     # idle 10 with away_threshold 5 -> defer; natural_threshold high so not natural
     r = step(states, ctx(idle=10), natural_threshold=300, away_threshold=5)
     assert r.defer_reason == "away"
+
+
+def test_step_empty_states_is_safe():
+    # No breaks configured (startup race / all breaks removed) must not crash.
+    r = step([], ctx(idle=0))
+    assert r.new_remaining == []
+    assert r.natural_break is False
+    assert r.fire_index is None and r.defer_reason is None

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,71 @@
+import sys
+import types
+
+import dfyb.activity.sensors as sensors
+
+
+def _fake_quartz_idle(value):
+    fake = types.ModuleType("Quartz")
+    fake.kCGEventSourceStateHIDSystemState = 1
+    fake.kCGAnyInputEventType = 0xFFFFFFFF
+    fake.CGEventSourceSecondsSinceLastEventType = lambda state, evtype: value
+    return fake
+
+
+def _fake_quartz_windows(windows, screen=(1920, 1080)):
+    fake = types.ModuleType("Quartz")
+    fake.kCGWindowListOptionOnScreenOnly = 1
+    fake.kCGWindowListExcludeDesktopElements = 16
+    fake.kCGNullWindowID = 0
+    fake.CGMainDisplayID = lambda: 1
+    fake.CGDisplayPixelsWide = lambda d: screen[0]
+    fake.CGDisplayPixelsHigh = lambda d: screen[1]
+    fake.CGWindowListCopyWindowInfo = lambda opts, wid: windows
+    return fake
+
+
+def test_idle_seconds_non_darwin_is_zero(monkeypatch):
+    monkeypatch.setattr(sensors.sys, "platform", "linux")
+    assert sensors.idle_seconds() == 0.0
+
+
+def test_idle_seconds_darwin_success(monkeypatch):
+    monkeypatch.setitem(sys.modules, "Quartz", _fake_quartz_idle(42.5))
+    monkeypatch.setattr(sensors.sys, "platform", "darwin")
+    assert sensors.idle_seconds() == 42.5
+
+
+def test_idle_seconds_failure_returns_zero(monkeypatch):
+    fake = _fake_quartz_idle(0)
+    def boom(*a, **k):
+        raise RuntimeError("quartz boom")
+    fake.CGEventSourceSecondsSinceLastEventType = boom
+    monkeypatch.setitem(sys.modules, "Quartz", fake)
+    monkeypatch.setattr(sensors.sys, "platform", "darwin")
+    assert sensors.idle_seconds() == 0.0
+
+
+def test_fullscreen_non_darwin_is_false(monkeypatch):
+    monkeypatch.setattr(sensors.sys, "platform", "linux")
+    assert sensors.frontmost_is_fullscreen() is False
+
+
+def test_fullscreen_true_when_window_covers_screen(monkeypatch):
+    win = {"kCGWindowLayer": 0, "kCGWindowBounds": {"Width": 1920, "Height": 1080}}
+    monkeypatch.setitem(sys.modules, "Quartz", _fake_quartz_windows([win]))
+    monkeypatch.setattr(sensors.sys, "platform", "darwin")
+    assert sensors.frontmost_is_fullscreen() is True
+
+
+def test_fullscreen_false_for_small_window(monkeypatch):
+    win = {"kCGWindowLayer": 0, "kCGWindowBounds": {"Width": 800, "Height": 600}}
+    monkeypatch.setitem(sys.modules, "Quartz", _fake_quartz_windows([win]))
+    monkeypatch.setattr(sensors.sys, "platform", "darwin")
+    assert sensors.frontmost_is_fullscreen() is False
+
+
+def test_read_context_combines_sensors(monkeypatch):
+    monkeypatch.setattr(sensors, "idle_seconds", lambda: 12.0)
+    monkeypatch.setattr(sensors, "frontmost_is_fullscreen", lambda: True)
+    c = sensors.read_context()
+    assert c.idle_seconds == 12.0 and c.is_fullscreen is True

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -64,6 +64,16 @@ def test_fullscreen_false_for_small_window(monkeypatch):
     assert sensors.frontmost_is_fullscreen() is False
 
 
+def test_fullscreen_failure_returns_false(monkeypatch):
+    fake = _fake_quartz_windows([])
+    def boom(*a, **k):
+        raise RuntimeError("quartz boom")
+    fake.CGMainDisplayID = boom
+    monkeypatch.setitem(sys.modules, "Quartz", fake)
+    monkeypatch.setattr(sensors.sys, "platform", "darwin")
+    assert sensors.frontmost_is_fullscreen() is False
+
+
 def test_read_context_combines_sensors(monkeypatch):
     monkeypatch.setattr(sensors, "idle_seconds", lambda: 12.0)
     monkeypatch.setattr(sensors, "frontmost_is_fullscreen", lambda: True)


### PR DESCRIPTION
## Summary

The fully-tested *brain* of Phase 1 "Perfect Timing" — no app integration yet (that's Phase 1b), so `launch.py` is untouched and behavior is unchanged.

- **`dfyb/scheduler/engine.py`** — pure decision engine (no Tk, no I/O). `step(states, ctx) -> StepResult` decides **fire / defer / natural-break** from a `Context`, plus `decide` / `is_natural_break` helpers and the `Context` / `BreakState` / `StepResult` frozen dataclasses. Never mutates its inputs.
- **`dfyb/activity/sensors.py`** — macOS `idle_seconds()` (Quartz) + `frontmost_is_fullscreen()` (CGWindowList heuristic) + `read_context()`. `Quartz` is imported **lazily inside each function**, and every path fails safe to today's behavior (idle=0 / fullscreen=False) off-macOS or on error.
- **`event_log.py`** — adds `BREAK_DEFERRED` and `NATURAL_BREAK` event types.
- **`requirements.txt`** — `pyobjc-framework-Quartz; sys_platform == "darwin"` (the marker keeps the Linux CI install green; the lazy import keeps the module importable on CI).

Behaviors this brain encodes (from the approved spec): natural-break detection (idle ≥ 5 min resets all timers), don't-interrupt-fullscreen, defer-when-away (idle ≥ 60 s).

## Test Plan

- [x] `pytest -q` → **55 passed** locally (CI should match)
- [x] Engine is pure — no `tkinter`/`customtkinter`/I/O imports
- [x] `import dfyb.activity.sensors` works without Quartz (CI-safe)
- [x] Real Quartz sanity check on macOS returned a live idle reading
- [x] `launch.py` untouched — no behavior change

## Next (Phase 1b)
Wire `read_context()` + `step()` + the `EventLog` into `BreakApp.timer_loop` (isolate a `BreakConfig→BreakState` adapter, log `StepResult` at the call-site, snapshot context once per tick). Verified by launching the app.