### PR TITLE
Phase 1b: context-aware break timing (fullscreen/away defer + event log)

### DIFF
--- a/dfyb/activity/sensors.py
+++ b/dfyb/activity/sensors.py
@@ -9,6 +9,12 @@ import sys
 
 from dfyb.scheduler.engine import Context
 
+# Max active displays to enumerate (well above any real Mac's monitor count).
+MAX_DISPLAYS = 16
+# A window counts as covering a display if it reaches each edge within this many
+# points — absorbs rounding between window bounds and display bounds.
+FULLSCREEN_COVER_TOLERANCE_PX = 2
+
 
 def idle_seconds():
     """Seconds since the last user input event (macOS). 0.0 elsewhere / on failure."""
@@ -24,32 +30,73 @@ def idle_seconds():
         return 0.0
 
 
-def frontmost_is_fullscreen():
-    """Best-effort: is the frontmost on-screen window covering the full display?
+def _window_covers_display(window, display, tol=FULLSCREEN_COVER_TOLERANCE_PX):
+    """True if `window` fully covers `display`. Each is an (x, y, w, h) rect in
+    global points (top-left origin), so a fullscreen window sits exactly on the
+    display it fills — this works for a smaller/offset second monitor too."""
+    wx, wy, ww, wh = window
+    dx, dy, dw, dh = display
+    return (
+        wx <= dx + tol
+        and wy <= dy + tol
+        and wx + ww >= dx + dw - tol
+        and wy + wh >= dy + dh - tol
+    )
 
-    False on non-macOS or any failure (fails safe — 'not fullscreen' => fire).
-    Heuristic: the first layer-0 (normal app) window in front-to-back order whose
-    bounds cover the main display is treated as fullscreen.
+
+def covers_any_display(windows, displays, tol=FULLSCREEN_COVER_TOLERANCE_PX):
+    """True if any window fully covers any display — the multi-monitor native
+    fullscreen heuristic. Pure (no Quartz), so it is unit-tested off macOS."""
+    return any(
+        _window_covers_display(window, display, tol)
+        for window in windows
+        for display in displays
+    )
+
+
+def _active_display_rects(Quartz):
+    """(x, y, w, h) in points for every active display."""
+    _err, ids, count = Quartz.CGGetActiveDisplayList(MAX_DISPLAYS, None, None)
+    rects = []
+    for display_id in list(ids)[:count]:
+        bounds = Quartz.CGDisplayBounds(display_id)
+        rects.append((bounds.origin.x, bounds.origin.y,
+                      bounds.size.width, bounds.size.height))
+    return rects
+
+
+def _layer0_window_rects(Quartz):
+    """(x, y, w, h) in points for each on-screen normal (layer-0) window."""
+    windows = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly
+        | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID,
+    )
+    rects = []
+    for window in windows:
+        if window.get("kCGWindowLayer", 1) != 0:
+            continue  # skip menu bar, dock, overlays — only normal app windows
+        bounds = window.get("kCGWindowBounds", {})
+        rects.append((bounds.get("X", 0.0), bounds.get("Y", 0.0),
+                      bounds.get("Width", 0.0), bounds.get("Height", 0.0)))
+    return rects
+
+
+def frontmost_is_fullscreen():
+    """Best-effort: is any app in native fullscreen on ANY display?
+
+    True when a normal (layer-0) on-screen window fully covers one of the active
+    displays — handles multiple monitors of different sizes and offsets, and a
+    thin auto-hide bar sitting in front of the fullscreen window. False on
+    non-macOS or any failure (fails safe — 'not fullscreen' => fire).
     """
     if sys.platform != "darwin":
         return False
     try:
         import Quartz
-        display = Quartz.CGMainDisplayID()
-        screen_w = Quartz.CGDisplayPixelsWide(display)
-        screen_h = Quartz.CGDisplayPixelsHigh(display)
-        windows = Quartz.CGWindowListCopyWindowInfo(
-            Quartz.kCGWindowListOptionOnScreenOnly
-            | Quartz.kCGWindowListExcludeDesktopElements,
-            Quartz.kCGNullWindowID,
-        )
-        for window in windows:
-            if window.get("kCGWindowLayer", 1) != 0:
-                continue  # skip menu bar, dock, overlays — only normal app windows
-            bounds = window.get("kCGWindowBounds", {})
-            return (bounds.get("Width", 0) >= screen_w
-                    and bounds.get("Height", 0) >= screen_h)
-        return False
+        displays = _active_display_rects(Quartz)
+        windows = _layer0_window_rects(Quartz)
+        return covers_any_display(windows, displays)
     except Exception:
         return False
 

--- a/dfyb/scheduler/adapter.py
+++ b/dfyb/scheduler/adapter.py
@@ -1,0 +1,19 @@
+"""Adapt the app's (Tk-bound) BreakConfig objects to plain BreakState snapshots."""
+from dfyb.scheduler.engine import BreakState
+
+
+def states_from_configs(configs):
+    """Map an iterable of BreakConfig-like objects to a list[BreakState].
+
+    Each config must expose `.remaining`, `.get_interval_seconds()`,
+    `.get_duration_seconds()`. This is the single place BreakConfig is read into
+    the pure engine's value type — the engine never sees a BreakConfig.
+    """
+    return [
+        BreakState(
+            remaining=c.remaining,
+            interval_seconds=c.get_interval_seconds(),
+            duration_seconds=c.get_duration_seconds(),
+        )
+        for c in configs
+    ]

--- a/dfyb/scheduler/tick.py
+++ b/dfyb/scheduler/tick.py
@@ -1,0 +1,36 @@
+"""Per-tick composition: run the engine and decide which events to log.
+
+Pure (no Tk, no I/O). The timer loop calls `advance` once per tick and applies
+the returned new_remaining / fire_index / events.
+"""
+from dfyb.activity.event_log import BREAK_DEFERRED, NATURAL_BREAK
+from dfyb.scheduler.engine import step
+
+# Episode markers used to dedup sustained idle/defer logging.
+IDLE_EPISODE = "idle"
+DEFERRED_EPISODE = "deferred"
+
+
+def events_for_tick(result, ctx, episode):
+    """Given a StepResult, the Context, and the previous episode marker, return
+    (events_to_log, new_episode). Logs a sustained idle/defer only once.
+
+    events_to_log is a list of (event_type, data_dict) tuples.
+    """
+    if result.natural_break:
+        if episode != IDLE_EPISODE:
+            return [(NATURAL_BREAK, {"idle_seconds": ctx.idle_seconds})], IDLE_EPISODE
+        return [], IDLE_EPISODE
+    if result.defer_reason is not None:
+        if episode != DEFERRED_EPISODE:
+            return [(BREAK_DEFERRED, {"reason": result.defer_reason})], DEFERRED_EPISODE
+        return [], DEFERRED_EPISODE
+    # fire, or nothing due -> episode ends; BREAK_TAKEN is logged on popup close.
+    return [], None
+
+
+def advance(states, ctx, episode):
+    """Run one tick. Returns (new_remaining, fire_index, events, new_episode)."""
+    result = step(states, ctx)
+    events, new_episode = events_for_tick(result, ctx, episode)
+    return result.new_remaining, result.fire_index, events, new_episode

--- a/dfyb/timer_lifecycle.py
+++ b/dfyb/timer_lifecycle.py
@@ -1,0 +1,19 @@
+"""Pure liveness rule for the app's single timer thread.
+
+Each timer session started by ``BreakApp.start()`` gets a monotonically
+increasing generation token. A running timer thread must stop the moment its
+own generation is no longer the current one — this prevents a thread left over
+from a previous session (revived when ``start()`` re-arms the shared
+running/stop flags) from ticking alongside the new session's thread.
+"""
+
+
+def timer_should_continue(running, stop_set, current_generation, my_generation):
+    """Return True only while this timer thread should keep ticking.
+
+    A thread keeps running iff the app is running, no stop was requested, and
+    this thread owns the current generation. A stale generation stops the
+    thread even when ``running`` is True and ``stop_set`` is False (the
+    start-after-reset revival case).
+    """
+    return running and not stop_set and current_generation == my_generation

--- a/launch.py
+++ b/launch.py
@@ -1339,17 +1339,20 @@ class BreakApp:
             if self.paused or self.active_popup:
                 continue
 
-            ctx = read_context()
-            states = states_from_configs(self.breaks)
-            new_remaining, fire_index, events, self._episode = advance(
-                states, ctx, self._episode
-            )
-            for config, remaining in zip(self.breaks, new_remaining):
-                config.remaining = remaining
-            for event_type, data in events:
-                self.event_log.append(event_type, **data)
-            if fire_index is not None:
-                self.trigger_break(self.breaks[fire_index])
+            try:
+                ctx = read_context()
+                states = states_from_configs(self.breaks)
+                new_remaining, fire_index, events, self._episode = advance(
+                    states, ctx, self._episode
+                )
+                for config, remaining in zip(self.breaks, new_remaining):
+                    config.remaining = remaining
+                for event_type, data in events:
+                    self.event_log.append(event_type, **data)
+                if fire_index is not None:
+                    self.trigger_break(self.breaks[fire_index])
+            except Exception as e:
+                logging.error(f"timer_loop tick failed: {e}", exc_info=True)
 
     def trigger_break(self, config):
         """Queue a break with the given configuration."""

--- a/launch.py
+++ b/launch.py
@@ -28,6 +28,7 @@ from dfyb.activity.event_log import EventLog, BREAK_TAKEN
 from dfyb.activity.sensors import read_context
 from dfyb.scheduler.adapter import states_from_configs
 from dfyb.scheduler.tick import advance
+from dfyb.timer_lifecycle import timer_should_continue
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -820,6 +821,7 @@ class BreakApp:
         self.break_start_time = None
         self.event_log = EventLog(EVENTS_FILE)
         self._episode = None  # idle/deferred dedup marker for the smart-timing loop
+        self._timer_generation = 0  # bumped each start(); stale threads exit
 
         # Default break configurations
         self.default_breaks = [
@@ -1216,7 +1218,11 @@ class BreakApp:
         )
         self.reset_btn.configure(state="normal")
 
-        threading.Thread(target=self.timer_loop, daemon=True).start()
+        # New generation so any not-yet-exited thread from a prior session stops.
+        self._timer_generation += 1
+        threading.Thread(
+            target=self.timer_loop, args=(self._timer_generation,), daemon=True
+        ).start()
 
     def toggle_pause(self):
         if not self.running:
@@ -1333,9 +1339,21 @@ class BreakApp:
 
     # ------------------ TIMER ------------------
 
-    def timer_loop(self):
-        """Single timer loop managing all breaks (context-aware via the scheduler)."""
-        while self.running and not self.stop_event.is_set():
+    def _record_event(self, event_type, **data):
+        """Persist a break event to the log and surface it on the console."""
+        self.event_log.append(event_type, **data)
+        logging.info("event: %s %s", event_type, data)
+
+    def timer_loop(self, generation):
+        """Single timer loop managing all breaks (context-aware via the scheduler).
+
+        Only the thread owning the current generation keeps running; a thread
+        left over from a previous session exits as soon as start() bumps it.
+        """
+        while timer_should_continue(
+            self.running, self.stop_event.is_set(),
+            self._timer_generation, generation,
+        ):
             time.sleep(1)
             if self.paused or self.active_popup:
                 continue
@@ -1349,8 +1367,14 @@ class BreakApp:
                 for config, remaining in zip(self.breaks, new_remaining):
                     config.remaining = remaining
                 for event_type, data in events:
-                    self.event_log.append(event_type, **data)
+                    self._record_event(event_type, **data)
                 if fire_index is not None:
+                    logging.info(
+                        "break due, firing: %s (idle=%.0fs fullscreen=%s)",
+                        self.breaks[fire_index].name.get(),
+                        ctx.idle_seconds,
+                        ctx.is_fullscreen,
+                    )
                     self.trigger_break(self.breaks[fire_index])
             except Exception as e:
                 logging.error(f"timer_loop tick failed: {e}", exc_info=True)
@@ -1387,7 +1411,7 @@ class BreakApp:
             # Runs on the main thread. EventLog.append has no internal lock, but the
             # timer thread skips all event-log writes while self.active_popup is set
             # (cleared further down), so this call never interleaves with the loop's appends.
-            self.event_log.append(
+            self._record_event(
                 BREAK_TAKEN,
                 name=break_data['name'],
                 duration=break_data['duration'],

--- a/launch.py
+++ b/launch.py
@@ -1203,6 +1203,7 @@ class BreakApp:
         self.running = True
         self.paused = False
         self.stop_event.clear()
+        self._episode = None  # fresh idle/deferred dedup marker each session
 
         for config in self.breaks:
             config.reset_timer()
@@ -1383,6 +1384,9 @@ class BreakApp:
 
         def on_popup_close():
             elapsed = int(time.time() - self.break_start_time) if self.break_start_time else 0
+            # Runs on the main thread. EventLog.append has no internal lock, but the
+            # timer thread skips all event-log writes while self.active_popup is set
+            # (cleared further down), so this call never interleaves with the loop's appends.
             self.event_log.append(
                 BREAK_TAKEN,
                 name=break_data['name'],

--- a/launch.py
+++ b/launch.py
@@ -24,6 +24,10 @@ from dfyb.updater import (
     HOMEBREW_CASK_NAME,
 )
 from dfyb.animation import ease_out_quad, prefers_reduced_motion
+from dfyb.activity.event_log import EventLog, BREAK_TAKEN
+from dfyb.activity.sensors import read_context
+from dfyb.scheduler.adapter import states_from_configs
+from dfyb.scheduler.tick import advance
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -80,6 +84,7 @@ if sys.platform == "darwin":
 TIME_UNITS = ["sec", "min", "hour"]
 CONFIG_FILE = Path.home() / "Library" / "Preferences" / "com.yairs.dontforgetyourbreaks.json"
 LOCK_FILE = Path.home() / "Library" / "Application Support" / "DontForgetYourBreaks" / ".lock"
+EVENTS_FILE = Path.home() / "Library" / "Application Support" / "DontForgetYourBreaks" / "events.jsonl"
 GITHUB_NEW_ISSUE_URL = "https://github.com/YairShachar/dont-forget-your-breaks/issues/new"
 UPDATE_CHECK_INTERVAL_HOURS = 24
 
@@ -813,6 +818,8 @@ class BreakApp:
         self.break_queue = []
         self.active_popup = None
         self.break_start_time = None
+        self.event_log = EventLog(EVENTS_FILE)
+        self._episode = None  # idle/deferred dedup marker for the smart-timing loop
 
         # Default break configurations
         self.default_breaks = [
@@ -1326,23 +1333,23 @@ class BreakApp:
     # ------------------ TIMER ------------------
 
     def timer_loop(self):
-        """Single timer loop managing all breaks."""
+        """Single timer loop managing all breaks (context-aware via the scheduler)."""
         while self.running and not self.stop_event.is_set():
             time.sleep(1)
             if self.paused or self.active_popup:
                 continue
 
-            fired_breaks = []
-            for config in self.breaks:
-                config.remaining -= 1
-                if config.remaining <= 0:
-                    fired_breaks.append(config)
-
-            if fired_breaks:
-                longest = max(fired_breaks, key=lambda c: c.get_duration_seconds())
-                for config in fired_breaks:
-                    config.reset_timer()
-                self.trigger_break(longest)
+            ctx = read_context()
+            states = states_from_configs(self.breaks)
+            new_remaining, fire_index, events, self._episode = advance(
+                states, ctx, self._episode
+            )
+            for config, remaining in zip(self.breaks, new_remaining):
+                config.remaining = remaining
+            for event_type, data in events:
+                self.event_log.append(event_type, **data)
+            if fire_index is not None:
+                self.trigger_break(self.breaks[fire_index])
 
     def trigger_break(self, config):
         """Queue a break with the given configuration."""
@@ -1373,6 +1380,12 @@ class BreakApp:
 
         def on_popup_close():
             elapsed = int(time.time() - self.break_start_time) if self.break_start_time else 0
+            self.event_log.append(
+                BREAK_TAKEN,
+                name=break_data['name'],
+                duration=break_data['duration'],
+                used_seconds=elapsed,
+            )
             for queued_break in self.break_queue:
                 queued_break['duration'] -= elapsed
 

--- a/tests/test_scheduler_adapter.py
+++ b/tests/test_scheduler_adapter.py
@@ -1,0 +1,26 @@
+from dfyb.scheduler.engine import BreakState
+from dfyb.scheduler.adapter import states_from_configs
+
+
+class FakeConfig:
+    """Duck-typed stand-in for BreakConfig (no Tk needed)."""
+    def __init__(self, remaining, interval, duration):
+        self.remaining = remaining
+        self._interval = interval
+        self._duration = duration
+
+    def get_interval_seconds(self):
+        return self._interval
+
+    def get_duration_seconds(self):
+        return self._duration
+
+
+def test_states_from_configs_maps_each_field():
+    configs = [FakeConfig(5, 100, 5), FakeConfig(8, 200, 600)]
+    states = states_from_configs(configs)
+    assert states == [BreakState(5, 100, 5), BreakState(8, 200, 600)]
+
+
+def test_states_from_configs_empty():
+    assert states_from_configs([]) == []

--- a/tests/test_scheduler_tick.py
+++ b/tests/test_scheduler_tick.py
@@ -53,6 +53,13 @@ def test_episode_transition_idle_to_deferred_relogs():
     assert ep == DEFERRED_EPISODE
 
 
+def test_episode_transition_deferred_to_idle_relogs():
+    # was deferring, now idle -> different episode, logs the natural break
+    events, ep = events_for_tick(R(natural_break=True), ctx(idle=400), DEFERRED_EPISODE)
+    assert events == [(NATURAL_BREAK, {"idle_seconds": 400})]
+    assert ep == IDLE_EPISODE
+
+
 # --- advance (composes step + events_for_tick) ---
 
 def test_advance_natural_break():

--- a/tests/test_scheduler_tick.py
+++ b/tests/test_scheduler_tick.py
@@ -1,0 +1,89 @@
+from dfyb.scheduler.engine import Context, BreakState
+from dfyb.activity.event_log import BREAK_DEFERRED, NATURAL_BREAK
+from dfyb.scheduler.tick import (
+    events_for_tick, advance, IDLE_EPISODE, DEFERRED_EPISODE,
+)
+
+
+def ctx(idle=0.0, fullscreen=False):
+    return Context(idle_seconds=idle, is_fullscreen=fullscreen)
+
+
+# --- events_for_tick (operates on a StepResult-like object) ---
+
+class R:
+    """Minimal StepResult stand-in for events_for_tick tests."""
+    def __init__(self, natural_break=False, fire_index=None, defer_reason=None):
+        self.natural_break = natural_break
+        self.fire_index = fire_index
+        self.defer_reason = defer_reason
+
+
+def test_natural_break_logs_once_then_dedups():
+    events, ep = events_for_tick(R(natural_break=True), ctx(idle=400), None)
+    assert events == [(NATURAL_BREAK, {"idle_seconds": 400})]
+    assert ep == IDLE_EPISODE
+    # same episode -> no repeat
+    events2, ep2 = events_for_tick(R(natural_break=True), ctx(idle=410), IDLE_EPISODE)
+    assert events2 == [] and ep2 == IDLE_EPISODE
+
+
+def test_defer_logs_once_then_dedups():
+    events, ep = events_for_tick(R(defer_reason="fullscreen"), ctx(), None)
+    assert events == [(BREAK_DEFERRED, {"reason": "fullscreen"})]
+    assert ep == DEFERRED_EPISODE
+    events2, ep2 = events_for_tick(R(defer_reason="fullscreen"), ctx(), DEFERRED_EPISODE)
+    assert events2 == [] and ep2 == DEFERRED_EPISODE
+
+
+def test_fire_clears_episode_and_logs_nothing():
+    events, ep = events_for_tick(R(fire_index=0), ctx(), DEFERRED_EPISODE)
+    assert events == [] and ep is None
+
+
+def test_nothing_due_clears_episode():
+    events, ep = events_for_tick(R(), ctx(), IDLE_EPISODE)
+    assert events == [] and ep is None
+
+
+def test_episode_transition_idle_to_deferred_relogs():
+    # was idle, now deferring -> different episode, logs the defer
+    events, ep = events_for_tick(R(defer_reason="away"), ctx(), IDLE_EPISODE)
+    assert events == [(BREAK_DEFERRED, {"reason": "away"})]
+    assert ep == DEFERRED_EPISODE
+
+
+# --- advance (composes step + events_for_tick) ---
+
+def test_advance_natural_break():
+    states = [BreakState(remaining=5, interval_seconds=100, duration_seconds=5)]
+    new_remaining, fire_index, events, ep = advance(states, ctx(idle=400), None)
+    assert new_remaining == [100]
+    assert fire_index is None
+    assert events == [(NATURAL_BREAK, {"idle_seconds": 400})]
+    assert ep == IDLE_EPISODE
+
+
+def test_advance_fires_when_due_and_active():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    new_remaining, fire_index, events, ep = advance(states, ctx(idle=0), None)
+    assert fire_index == 0
+    assert new_remaining == [100]
+    assert events == []          # BREAK_TAKEN is logged on popup close, not here
+    assert ep is None
+
+
+def test_advance_defers_on_fullscreen():
+    states = [BreakState(remaining=1, interval_seconds=100, duration_seconds=5)]
+    new_remaining, fire_index, events, ep = advance(states, ctx(fullscreen=True), None)
+    assert fire_index is None
+    assert new_remaining == [0]  # clamped
+    assert events == [(BREAK_DEFERRED, {"reason": "fullscreen"})]
+    assert ep == DEFERRED_EPISODE
+
+
+def test_advance_decrements_when_not_due():
+    states = [BreakState(remaining=5, interval_seconds=100, duration_seconds=5)]
+    new_remaining, fire_index, events, ep = advance(states, ctx(idle=0), None)
+    assert new_remaining == [4]
+    assert fire_index is None and events == [] and ep is None

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -12,15 +12,22 @@ def _fake_quartz_idle(value):
     return fake
 
 
-def _fake_quartz_windows(windows, screen=(1920, 1080)):
+class _FakeBounds:
+    """Stand-in for a Quartz CGRect: .origin.x/.y and .size.width/.height."""
+    def __init__(self, x, y, w, h):
+        self.origin = types.SimpleNamespace(x=x, y=y)
+        self.size = types.SimpleNamespace(width=w, height=h)
+
+
+def _fake_quartz_windows(windows, displays=((0, 0, 1920, 1080),)):
     fake = types.ModuleType("Quartz")
     fake.kCGWindowListOptionOnScreenOnly = 1
     fake.kCGWindowListExcludeDesktopElements = 16
     fake.kCGNullWindowID = 0
-    fake.CGMainDisplayID = lambda: 1
-    fake.CGDisplayPixelsWide = lambda d: screen[0]
-    fake.CGDisplayPixelsHigh = lambda d: screen[1]
     fake.CGWindowListCopyWindowInfo = lambda opts, wid: windows
+    display_ids = list(range(1, len(displays) + 1))
+    fake.CGGetActiveDisplayList = lambda maxd, a, b: (0, display_ids, len(displays))
+    fake.CGDisplayBounds = lambda did: _FakeBounds(*displays[did - 1])
     return fake
 
 
@@ -68,7 +75,7 @@ def test_fullscreen_failure_returns_false(monkeypatch):
     fake = _fake_quartz_windows([])
     def boom(*a, **k):
         raise RuntimeError("quartz boom")
-    fake.CGMainDisplayID = boom
+    fake.CGGetActiveDisplayList = boom
     monkeypatch.setitem(sys.modules, "Quartz", fake)
     monkeypatch.setattr(sensors.sys, "platform", "darwin")
     assert sensors.frontmost_is_fullscreen() is False
@@ -79,3 +86,44 @@ def test_read_context_combines_sensors(monkeypatch):
     monkeypatch.setattr(sensors, "frontmost_is_fullscreen", lambda: True)
     c = sensors.read_context()
     assert c.idle_seconds == 12.0 and c.is_fullscreen is True
+
+
+# --- covers_any_display: pure multi-monitor fullscreen logic ---
+# Real geometry captured from a dual-monitor Mac (main + smaller offset second).
+MAIN_DISPLAY = (0, 0, 1920, 1080)
+SECOND_DISPLAY = (1920, 64, 1512, 982)
+DISPLAYS = [MAIN_DISPLAY, SECOND_DISPLAY]
+
+
+def test_covers_fullscreen_on_main_display():
+    windows = [(0, 0, 1920, 1080), (2302, 97, 1130, 949)]
+    assert sensors.covers_any_display(windows, DISPLAYS) is True
+
+
+def test_covers_fullscreen_on_secondary_display():
+    # Regression: native fullscreen on the smaller, offset second monitor used
+    # to be missed because only the main display was checked.
+    windows = [(1920, 64, 1512, 982), (0, 122, 1920, 958)]
+    assert sensors.covers_any_display(windows, DISPLAYS) is True
+
+
+def test_windowed_chrome_is_not_fullscreen():
+    # Menu-bar-visible windowed content sits below y=0, so it covers nothing.
+    windows = [(0, 0, 1920, 41), (0, 122, 1920, 958), (2302, 97, 1130, 949)]
+    assert sensors.covers_any_display(windows, DISPLAYS) is False
+
+
+def test_thin_bar_in_front_of_fullscreen_window_still_detected():
+    # A thin auto-hide bar is frontmost; the real full window is later in the
+    # list. Scanning all windows (not just the first) still detects fullscreen.
+    windows = [(0, 0, 1920, 41), (0, 0, 1920, 1080)]
+    assert sensors.covers_any_display(windows, DISPLAYS) is True
+
+
+def test_covers_within_rounding_tolerance():
+    assert sensors.covers_any_display([(0, 0, 1919, 1079)], [MAIN_DISPLAY]) is True
+
+
+def test_no_windows_or_no_displays_is_false():
+    assert sensors.covers_any_display([], DISPLAYS) is False
+    assert sensors.covers_any_display([MAIN_DISPLAY], []) is False

--- a/tests/test_timer_lifecycle.py
+++ b/tests/test_timer_lifecycle.py
@@ -1,0 +1,35 @@
+"""Regression tests for the timer-thread liveness rule.
+
+Bug: pressing Reset then Start quickly could revive a previous timer thread —
+both the old and new thread stayed alive, so breaks fired multiple times. The
+fix gives each timer session a generation token; a thread only keeps running
+while its own generation is the current one.
+"""
+from dfyb.timer_lifecycle import timer_should_continue
+
+
+def test_current_generation_and_running_continues():
+    assert timer_should_continue(
+        running=True, stop_set=False, current_generation=3, my_generation=3
+    ) is True
+
+
+def test_stale_generation_stops_even_if_running_and_not_stopped():
+    # The revival case: a previous thread whose session was superseded by a new
+    # start(). running is True and stop is clear (start() re-armed them), but the
+    # generation moved on, so the old thread must stop.
+    assert timer_should_continue(
+        running=True, stop_set=False, current_generation=4, my_generation=3
+    ) is False
+
+
+def test_not_running_stops():
+    assert timer_should_continue(
+        running=False, stop_set=False, current_generation=1, my_generation=1
+    ) is False
+
+
+def test_stop_set_stops():
+    assert timer_should_continue(
+        running=True, stop_set=True, current_generation=1, my_generation=1
+    ) is False


### PR DESCRIPTION
## Phase 1b — Timer-Loop Integration ("Perfect Timing" goes live)

Wires the pure Phase 1a scheduler + sensors into the running app so break timers become **context-aware**: breaks defer during fullscreen, reset on natural breaks (long idle), and every decision is logged to an append-only event log.

Plan: `docs/plans/2026-06-16-phase-1b-timer-integration.md` · Spec: `docs/specs/2026-06-16-phase-1-perfect-timing-design.md` (§6)

### What changed
- **`dfyb/scheduler/adapter.py`** — `states_from_configs()`: the single place a Tk-bound `BreakConfig` is read into the pure engine's `BreakState`.
- **`dfyb/scheduler/tick.py`** — `advance()` composes `step` + episode-dedup event logic so the timer loop calls one pure function; logs a sustained idle/defer only once.
- **`launch.py`** — `timer_loop` now reads context, runs `advance`, writes back, logs events, and triggers; `EventLog` writes to `~/Library/Application Support/DontForgetYourBreaks/events.jsonl` (new `EVENTS_FILE` constant); `BREAK_TAKEN` logged on popup close with `used_seconds`. Old blind countdown removed (single reset path).
- Timer thread hardened with an exception guard (matches the existing `_check_for_updates_bg` convention) so a transient event-log I/O failure can't silently kill the loop.

### Testing
- **67 passing** (`.venv/bin/python -m pytest -q`) — 12 new pure-logic tests across adapter + tick.
- Headless end-to-end check drives adapter→advance→event-log over defer/natural-break ticks → `INTEGRATION-OK`.
- Launch-smoke: app starts with no traceback.

### Review
- Per-task spec+quality reviews (all clean) + a whole-branch review: **ready to merge**, no Critical/Important findings.
- One review finding fixed in-branch (timer-thread exception guard). Deferred fast-follow (non-blocking): log-once/backoff if a per-tick failure is persistent.

### Manual verification before merge (recommended)
Run the app, set a short Micro Break interval, Start, then confirm in `events.jsonl`:
- Popup → Done writes a `break_taken` line.
- Another app fullscreen when a break is due → no popup, `break_deferred` line; leave fullscreen → it pops.
- Step away ~5 min → `natural_break` line and timers reset.
