### PR TITLE
Fix #21: break popup no longer switches Spaces on multi-monitor

### DIFF
--- a/dfyb/macos_window.py
+++ b/dfyb/macos_window.py
@@ -1,50 +1,73 @@
-"""Make a Tk window non-intrusive on macOS: appear on the currently active
-Space and float on top WITHOUT activating the app (which is what makes macOS
-switch Spaces / steal focus).
+"""Pin a break popup to the active Space on macOS so it shows where the user is
+looking WITHOUT switching Spaces (the multi-monitor #21 fix).
 
-Best-effort and platform-guarded, like dfyb/activity/sensors.py: a documented
-no-op on non-macOS or on any failure, so callers never need to guard.
+The caller handles visibility/focus (lift + focus_force); this module only makes
+the window join the active Space and float above other windows, so activating it
+doesn't drag the user to a different Space.
+
+Best-effort and platform-guarded, like dfyb/activity/sensors.py: a no-op on
+non-macOS or on any failure, so callers never need to guard.
+
+Runs from a <Map> binding, not inline: Tk maps the window asynchronously on a
+Cocoa VisibilityNotify, so the NSWindow isn't ready (or found) until then. The
+<Map> handler runs before Tk's own activation, so the Space membership is set
+before the window activates.
 """
 import logging
 import sys
 
-# NSFloatingWindowLevel — above normal windows, no focus required. Hardcoding
-# the numeric value avoids importing AppKit just to read the constant.
-FLOATING_WINDOW_LEVEL = 3
 
+def pin_to_active_space(window):
+    """Make a Tk Toplevel appear on the active Space and float on top, without
+    switching Spaces. Call once, right after creating the window. macOS-only.
 
-def make_nonintrusive(window):
-    """Float `window` (a Tk Toplevel) on the active Space without activating
-    the app. macOS-only; a documented no-op on other platforms.
-
-    Not implemented on Windows/Linux yet. A future implementation would:
-      * Windows: SetWindowPos(HWND_TOPMOST) + WS_EX_NOACTIVATE extended style.
-      * Linux/X11: _NET_WM_STATE_ABOVE + _NET_WM_STATE_SKIP_TASKBAR, no focus grab.
+    Not implemented on Windows/Linux yet. A future implementation would keep the
+    window above others without a workspace switch:
+      * Windows: SetWindowPos(HWND_TOPMOST).
+      * Linux/X11: _NET_WM_STATE_ABOVE, no workspace change.
     """
-    if sys.platform == "darwin":
-        _make_nonintrusive_macos(window)
+    if sys.platform != "darwin":
+        return
+    try:
+        window.bind("<Map>", _on_map_handler(window), add="+")
+    except Exception:
+        logging.debug("pin_to_active_space: setup failed", exc_info=True)
 
 
-def _make_nonintrusive_macos(window):
-    """Set the popup's NSWindow to join all Spaces + float, and order it front
-    without activating. Any failure is swallowed (best-effort)."""
+def _on_map_handler(window):
+    """Build a <Map> handler that configures the NSWindow when the toplevel maps.
+    Guards on the widget so child-widget Map events don't re-run it."""
+    def _handle(event):
+        if str(event.widget) == str(window):
+            _configure_nswindow(window)
+    return _handle
+
+
+def _configure_nswindow(window):
+    """Set the popup's NSWindow to join the active Space and float high, so
+    activating it does not switch Spaces. Runs from <Map>. Best-effort."""
     try:
         from AppKit import (
             NSApplication,
+            NSStatusWindowLevel,
             NSWindowCollectionBehaviorCanJoinAllSpaces,
+            NSWindowCollectionBehaviorFullScreenAuxiliary,
+            NSWindowCollectionBehaviorStationary,
         )
 
         app = NSApplication.sharedApplication()
         ns_window = _find_nswindow(window, app)
         if ns_window is None:
             return
+        ns_window.setLevel_(NSStatusWindowLevel)
         ns_window.setCollectionBehavior_(
-            ns_window.collectionBehavior() | NSWindowCollectionBehaviorCanJoinAllSpaces
+            ns_window.collectionBehavior()
+            | NSWindowCollectionBehaviorCanJoinAllSpaces  # show on active Space, don't switch
+            | NSWindowCollectionBehaviorFullScreenAuxiliary
+            | NSWindowCollectionBehaviorStationary
         )
-        ns_window.setLevel_(FLOATING_WINDOW_LEVEL)
-        ns_window.orderFrontRegardless()  # show on top WITHOUT activating the app
     except Exception:
-        logging.debug("make_nonintrusive: no-op (macOS tweak failed)", exc_info=True)
+        logging.debug("pin_to_active_space: NSWindow config failed", exc_info=True)
 
 
 def _find_nswindow(window, app):

--- a/dfyb/macos_window.py
+++ b/dfyb/macos_window.py
@@ -1,0 +1,60 @@
+"""Make a Tk window non-intrusive on macOS: appear on the currently active
+Space and float on top WITHOUT activating the app (which is what makes macOS
+switch Spaces / steal focus).
+
+Best-effort and platform-guarded, like dfyb/activity/sensors.py: a documented
+no-op on non-macOS or on any failure, so callers never need to guard.
+"""
+import logging
+import sys
+
+# NSFloatingWindowLevel — above normal windows, no focus required. Hardcoding
+# the numeric value avoids importing AppKit just to read the constant.
+FLOATING_WINDOW_LEVEL = 3
+
+
+def make_nonintrusive(window):
+    """Float `window` (a Tk Toplevel) on the active Space without activating
+    the app. macOS-only; a documented no-op on other platforms.
+
+    Not implemented on Windows/Linux yet. A future implementation would:
+      * Windows: SetWindowPos(HWND_TOPMOST) + WS_EX_NOACTIVATE extended style.
+      * Linux/X11: _NET_WM_STATE_ABOVE + _NET_WM_STATE_SKIP_TASKBAR, no focus grab.
+    """
+    if sys.platform == "darwin":
+        _make_nonintrusive_macos(window)
+
+
+def _make_nonintrusive_macos(window):
+    """Set the popup's NSWindow to join all Spaces + float, and order it front
+    without activating. Any failure is swallowed (best-effort)."""
+    try:
+        from AppKit import (
+            NSApplication,
+            NSWindowCollectionBehaviorCanJoinAllSpaces,
+        )
+
+        app = NSApplication.sharedApplication()
+        ns_window = _find_nswindow(window, app)
+        if ns_window is None:
+            return
+        ns_window.setCollectionBehavior_(
+            ns_window.collectionBehavior() | NSWindowCollectionBehaviorCanJoinAllSpaces
+        )
+        ns_window.setLevel_(FLOATING_WINDOW_LEVEL)
+        ns_window.orderFrontRegardless()  # show on top WITHOUT activating the app
+    except Exception:
+        logging.debug("make_nonintrusive: no-op (macOS tweak failed)", exc_info=True)
+
+
+def _find_nswindow(window, app):
+    """Locate the NSWindow backing a Tk Toplevel by matching its title.
+
+    Isolated so the (fragile) lookup strategy can be swapped without touching
+    callers. Returns None if not found.
+    """
+    title = window.title()
+    for ns_window in app.windows():
+        if ns_window.title() == title:
+            return ns_window
+    return None

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,24 @@
+# Development Conventions
+
+## Platform-specific behavior (macOS-first)
+
+This app is macOS-first; cross-platform is out of scope. When you add
+platform-specific behavior:
+
+1. **Graceful fallback** — guard with `sys.platform == "darwin"` (or the
+   relevant platform) and degrade to a safe no-op/alternative; never let a
+   platform-only call crash elsewhere.
+2. **Document the gap** — state in the code what other platforms don't get.
+3. **Leave a named seam** — structure it as a dispatcher and name the concrete
+   API a future platform implementation would use, so it can slot in later.
+
+Reference implementations: `dfyb/macos_window.py`, `dfyb/activity/sensors.py`.
+
+## Make behaviors configurable
+
+User-facing behaviors should be **user preferences with sensible defaults**, not
+hardcoded policy. If a behavior changes what the user experiences — whether
+breaks defer during fullscreen, sounds, timings, and other "cool" features —
+prefer a preference (read with a `.get(key, default)` fallback for backward
+compatibility) over a fixed behavior. Zero-config defaults are the goal, but the
+user should be able to turn a behavior off.

--- a/docs/plans/2026-07-02-popup-nonintrusive.md
+++ b/docs/plans/2026-07-02-popup-nonintrusive.md
@@ -1,0 +1,432 @@
+# Non-intrusive Break Popup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Human-in-the-loop:** Tasks 2 and 3 have a **live verification gate on a real dual-monitor Mac** (macOS Space behavior is empirical and cannot be unit-tested). The controller MUST pause at those gates and have the human run the app and confirm the observed behavior before proceeding.
+
+**Goal:** Make the break popup appear on the user's current Space/display without stealing keyboard focus or switching Spaces (fixes issue #21 on multi-monitor).
+
+**Architecture:** All macOS window manipulation lives in one new isolated, platform-guarded helper `dfyb/macos_window.py` (dispatcher → macOS impl → swappable NSWindow lookup), mirroring `dfyb/activity/sensors.py`. `CountdownPopup` stops calling `focus_force()` and calls `make_nonintrusive(window)` instead; the focus-steal/restore machinery (`_prevent_focus_steal`, `_get_frontmost_app`, AppleScript `activate`) is retired because nothing steals focus anymore.
+
+**Tech Stack:** Python 3, Tkinter/CustomTkinter, pyobjc (AppKit), pytest.
+
+**Spec:** `~/daily/specs/2026-07-02-popup-nonintrusive-design.md`
+
+## Global Constraints
+
+- **Interruption model:** *appear, don't hijack* — the popup floats on top of the current Space with sound/flash; it must NOT activate the app, take keyboard focus, or switch any Space. Once the user deliberately clicks it, activating is acceptable.
+- **Platform discipline:** all macOS-only code guarded by `sys.platform == "darwin"` with a graceful fallback; never crash on other platforms. Platform-specific behavior must (a) fall back gracefully, (b) document what other platforms don't get, (c) leave a named seam for a future implementation.
+- **No hardcoded magic values** — named constants (this plan adds `FLOATING_WINDOW_LEVEL`).
+- **Preferences backward-compatible** — n/a here (no new prefs).
+- **Don't regress the popup countdown/snooze/auto-dismiss behavior.**
+- **Tests:** `pytest`, files `tests/test_*.py`, run with `.venv/bin/python -m pytest -q`. Existing baseline: **77 passed**.
+- **Commits:** conventional-commit summary only, no body, no co-author trailer.
+
+## Repo conventions
+
+- Run everything through the venv: `.venv/bin/python`, `.venv/bin/pip`.
+- Repo is under `~/data/projects/` → personal git identity applies automatically. No identity flags.
+- `gh` for issues uses the personal config: prefix with `GH_CONFIG_DIR="$HOME/.config/gh-personal"`.
+- Push before PR; verify the PR diff + CI test count before claiming done.
+
+## Pre-flight (run once before Task 1)
+
+```bash
+cd ~/data/projects/dont_forget_your_breaks
+git checkout main && git pull --ff-only origin main
+.venv/bin/python -m pytest -q            # baseline: 77 passed
+git checkout -b popup-nonintrusive
+.venv/bin/python -c "import AppKit; print('pyobjc AppKit present')"   # confirm pyobjc is installed
+```
+If the AppKit import fails, STOP — the macOS impl needs pyobjc (`.venv/bin/pip install pyobjc`).
+
+---
+
+### Task 1: Isolated macOS window helper `dfyb/macos_window.py`
+
+**Files:**
+- Create: `dfyb/macos_window.py`
+- Test: `tests/test_macos_window.py`
+
+**Interfaces:**
+- Produces: `make_nonintrusive(window) -> None` — configure a Tk `Toplevel` to float on the current Space without activating the app. macOS-only; documented no-op elsewhere. Best-effort: never raises.
+
+This task is pure module creation with the platform-guard/fallback path unit-tested. The actual NSWindow side effects are validated live in Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_macos_window.py`:
+```python
+import dfyb.macos_window as macos_window
+
+
+def test_make_nonintrusive_is_noop_off_macos(monkeypatch):
+    monkeypatch.setattr(macos_window.sys, "platform", "linux")
+    # Must not touch the window and must not raise on non-macOS.
+    macos_window.make_nonintrusive(object())
+
+
+def test_make_nonintrusive_swallows_failure_on_darwin(monkeypatch):
+    monkeypatch.setattr(macos_window.sys, "platform", "darwin")
+    # A bad window (no .title()) / missing AppKit must be caught -> no raise.
+    macos_window.make_nonintrusive(object())
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_macos_window.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'dfyb.macos_window'`
+
+- [ ] **Step 3: Create the module**
+
+Create `dfyb/macos_window.py`:
+```python
+"""Make a Tk window non-intrusive on macOS: appear on the currently active
+Space and float on top WITHOUT activating the app (which is what makes macOS
+switch Spaces / steal focus).
+
+Best-effort and platform-guarded, like dfyb/activity/sensors.py: a documented
+no-op on non-macOS or on any failure, so callers never need to guard.
+"""
+import logging
+import sys
+
+# NSFloatingWindowLevel — above normal windows, no focus required. Hardcoding
+# the numeric value avoids importing AppKit just to read the constant.
+FLOATING_WINDOW_LEVEL = 3
+
+
+def make_nonintrusive(window):
+    """Float `window` (a Tk Toplevel) on the active Space without activating
+    the app. macOS-only; a documented no-op on other platforms.
+
+    Not implemented on Windows/Linux yet. A future implementation would:
+      * Windows: SetWindowPos(HWND_TOPMOST) + WS_EX_NOACTIVATE extended style.
+      * Linux/X11: _NET_WM_STATE_ABOVE + _NET_WM_STATE_SKIP_TASKBAR, no focus grab.
+    """
+    if sys.platform == "darwin":
+        _make_nonintrusive_macos(window)
+
+
+def _make_nonintrusive_macos(window):
+    """Set the popup's NSWindow to join all Spaces + float, and order it front
+    without activating. Any failure is swallowed (best-effort)."""
+    try:
+        from AppKit import NSApp, NSWindowCollectionBehaviorCanJoinAllSpaces
+
+        ns_window = _find_nswindow(window, NSApp)
+        if ns_window is None:
+            return
+        ns_window.setCollectionBehavior_(
+            ns_window.collectionBehavior() | NSWindowCollectionBehaviorCanJoinAllSpaces
+        )
+        ns_window.setLevel_(FLOATING_WINDOW_LEVEL)
+        ns_window.orderFrontRegardless()  # show on top WITHOUT activating the app
+    except Exception:
+        logging.debug("make_nonintrusive: no-op (macOS tweak failed)", exc_info=True)
+
+
+def _find_nswindow(window, ns_app):
+    """Locate the NSWindow backing a Tk Toplevel by matching its title.
+
+    Isolated so the (fragile) lookup strategy can be swapped without touching
+    callers. Returns None if not found.
+    """
+    title = window.title()
+    for ns_window in ns_app.windows():
+        if ns_window.title() == title:
+            return ns_window
+    return None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_macos_window.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS (79 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dfyb/macos_window.py tests/test_macos_window.py
+git commit -m "feat: add macos_window.make_nonintrusive helper with platform fallback"
+```
+
+---
+
+### Task 2: Wire into CountdownPopup + LIVE SPIKE GATE
+
+**Files:**
+- Modify: `launch.py` (imports; `CountdownPopup` show path)
+
+**Interfaces:**
+- Consumes: `make_nonintrusive` from Task 1.
+
+This is the de-risk gate: the *minimal* wiring (drop `focus_force()` on show, call `make_nonintrusive`) proven live BEFORE the larger retirement in Task 3. No unit tests — verified by launching the app on the real dual-monitor rig.
+
+- [ ] **Step 1: Add the import**
+
+In `launch.py`, find the existing line:
+```python
+from dfyb.timer_lifecycle import timer_should_continue
+```
+and add immediately after it:
+```python
+from dfyb.macos_window import make_nonintrusive
+```
+
+- [ ] **Step 2: Replace focus_force on show**
+
+In `launch.py`, in `CountdownPopup.__init__`, find:
+```python
+        # Force focus and request attention
+        self.window.lift()
+        self.window.focus_force()
+        self._request_attention()
+```
+and replace with:
+```python
+        # Appear on top of the current Space without activating the app
+        # (activating is what makes macOS steal focus / switch Spaces).
+        self.window.lift()
+        make_nonintrusive(self.window)
+        self._request_attention()
+```
+
+- [ ] **Step 3: Full suite still green**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: PASS (79 passed — no new tests here; nothing regressed)
+
+- [ ] **Step 4: Launch-smoke**
+
+Run: `timeout 6 .venv/bin/python launch.py; echo "exit=$? (124=ran fine)"`
+Expected: `exit=124`, no traceback.
+
+- [ ] **Step 5: HUMAN LIVE GATE — dual-monitor + fullscreen**
+
+The human runs the app, sets the Micro Break interval to a few seconds, presses Start, and on a **dual-monitor** setup:
+1. Puts an app in native (green-button) fullscreen on the **second** monitor and stays there.
+2. Lets a break come due.
+
+**Pass criteria (all must hold):**
+- The popup appears on the **currently active** Space/display.
+- The **second monitor's Space is NOT switched** (this is the bug being fixed).
+- The **foreground app keeps keyboard focus** (you can keep typing).
+- The Done/Snooze buttons are usable (note if it takes an extra "activating" click — acceptable per spec; just record it).
+
+**If any fail:** STOP and report. Likely causes: `_find_nswindow` didn't match (title mismatch/timing) or `canJoinAllSpaces` insufficient. Do NOT proceed to Task 3 until the gate passes.
+
+- [ ] **Step 6: Commit (only after the gate passes)**
+
+```bash
+git add launch.py
+git commit -m "feat: show break popup non-intrusively (no focus/Space steal)"
+```
+
+---
+
+### Task 3: Retire the focus-steal machinery
+
+**Files:**
+- Modify: `launch.py` (`CountdownPopup`: `__init__`, `close`, remove `_get_frontmost_app` + `_prevent_focus_steal`, strip `focus_force` from `bring_to_user` + `_bring_to_attention`)
+
+With focus no longer stolen, the restore machinery (which used AppleScript `activate` — the *other* Space-switcher) is dead weight. Remove it. Verified by launch + a second human live check.
+
+- [ ] **Step 1: Drop the previous-app capture**
+
+In `launch.py`, `CountdownPopup.__init__`, find:
+```python
+        self._previous_app = self._get_frontmost_app()  # Remember active app
+```
+and delete that line.
+
+- [ ] **Step 2: Simplify `close()`**
+
+In `launch.py`, find:
+```python
+        try:
+            self.window.withdraw()
+        except Exception:
+            pass
+        self._prevent_focus_steal()  # Call before destroy to prevent focus transfer
+        self.window.destroy()
+        self._prevent_focus_steal()  # Call again after to ensure app is deactivated
+```
+and replace with:
+```python
+        try:
+            self.window.withdraw()
+        except Exception:
+            pass
+        self.window.destroy()
+```
+
+- [ ] **Step 3: Remove the two dead methods**
+
+In `launch.py`, delete the entire `_get_frontmost_app` method and the entire `_prevent_focus_steal` method (they are no longer referenced after Steps 1-2).
+
+- [ ] **Step 4: Strip `focus_force` from `bring_to_user`**
+
+In `launch.py`, in `bring_to_user`, find:
+```python
+            self.window.lift()
+            self.window.focus_force()
+            self.window.attributes('-topmost', True)
+```
+and replace with:
+```python
+            self.window.lift()
+            make_nonintrusive(self.window)
+            self.window.attributes('-topmost', True)
+```
+
+- [ ] **Step 5: Strip `focus_force` from `_bring_to_attention`**
+
+In `launch.py`, in `_bring_to_attention`, find:
+```python
+            self.window.lift()
+            self.window.focus_force()
+            self.window.attributes('-topmost', True)
+            self._flash_button()
+```
+and replace with:
+```python
+            self.window.lift()
+            make_nonintrusive(self.window)
+            self.window.attributes('-topmost', True)
+            self._flash_button()
+```
+
+- [ ] **Step 6: Confirm no stray references remain**
+
+Run: `grep -n "focus_force\|_prevent_focus_steal\|_get_frontmost_app\|_previous_app" launch.py`
+Expected: **no matches** (all removed).
+
+- [ ] **Step 7: Full suite + launch-smoke**
+
+Run: `.venv/bin/python -m pytest -q` → Expected: PASS (79 passed)
+Run: `timeout 6 .venv/bin/python launch.py; echo "exit=$? (124=ran fine)"` → Expected: `exit=124`, no traceback.
+
+- [ ] **Step 8: HUMAN LIVE GATE — close/snooze behavior**
+
+The human triggers a break and confirms:
+- Closing the popup (Done) does NOT switch Spaces or yank focus (previously the AppleScript `activate` could).
+- Snooze and auto-dismiss still work; the countdown/progress is unaffected.
+
+**If any fail:** STOP and report.
+
+- [ ] **Step 9: Commit (after the gate passes)**
+
+```bash
+git add launch.py
+git commit -m "refactor: retire popup focus-steal machinery (no longer needed)"
+```
+
+---
+
+### Task 4: Record the platform-specific-change convention
+
+**Files:**
+- Modify: `CLAUDE.md` (project-local, gitignored — extend the existing rule)
+- Create: `docs/conventions.md` (committed)
+
+- [ ] **Step 1: Extend the project CLAUDE.md rule**
+
+In `CLAUDE.md`, find the development rule that begins:
+```
+- **Keep platform branches explicit.** Guard macOS-only code with `sys.platform == "darwin"` and provide a graceful fallback; never let a macOS-only call crash on Windows/Linux.
+```
+and append to that same bullet:
+```
+ When you add platform-specific behavior: (a) provide a graceful fallback, (b) document what other platforms don't get, (c) leave a named seam for a future implementation (see `dfyb/macos_window.py` and `dfyb/activity/sensors.py`). See `docs/conventions.md`.
+```
+
+- [ ] **Step 2: Create the committed conventions doc**
+
+Create `docs/conventions.md`:
+```markdown
+# Development Conventions
+
+## Platform-specific behavior (macOS-first)
+
+This app is macOS-first; cross-platform is out of scope. When you add
+platform-specific behavior:
+
+1. **Graceful fallback** — guard with `sys.platform == "darwin"` (or the
+   relevant platform) and degrade to a safe no-op/alternative; never let a
+   platform-only call crash elsewhere.
+2. **Document the gap** — state in the code what other platforms don't get.
+3. **Leave a named seam** — structure it as a dispatcher so a future platform
+   implementation can slot in, and name the concrete API a future impl would
+   use.
+
+Reference implementations: `dfyb/macos_window.py`, `dfyb/activity/sensors.py`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/conventions.md CLAUDE.md
+git commit -m "docs: record platform-specific-change convention"
+```
+Note: `CLAUDE.md` is gitignored, so only `docs/conventions.md` will actually be committed — that's expected; the CLAUDE.md edit is local guidance.
+
+---
+
+### Task 5: Roadmap note + follow-up issues
+
+**Files:**
+- Modify: `docs/specs/2026-06-11-roadmap-design.md` (append a note under Phase 4)
+
+- [ ] **Step 1: Add the roadmap note**
+
+In `docs/specs/2026-06-11-roadmap-design.md`, under the **Phase 4 — Delight & invisible** section, add a bullet:
+```
+- **Break presentation & barge-in UX** — entrance animation, how the popup grabs attention without hijacking, dismiss/snooze feel. (Follows the non-intrusive popup fix, issue #21.)
+```
+
+- [ ] **Step 2: Commit the roadmap note**
+
+```bash
+git add docs/specs/2026-06-11-roadmap-design.md
+git commit -m "docs: note break presentation/barge-in UX in Phase 4 roadmap"
+```
+
+- [ ] **Step 3: File the two follow-up GitHub issues (personal gh)**
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-personal" gh issue create \
+  --title "Configurable: defer breaks during fullscreen (opt to be reminded even in fullscreen)" \
+  --body "Today fullscreen always defers. Make it a preference (default: defer on). A pref gating the scheduler's fullscreen-defer. Enabled cleanly by #21 (the non-intrusive popup appears on the fullscreen Space instead of switching Spaces)."
+
+GH_CONFIG_DIR="$HOME/.config/gh-personal" gh issue create \
+  --title "Break presentation & barge-in UX polish (animation, attention-without-hijack)" \
+  --body "Roadmap Phase 4. Entrance animation, how the popup grabs attention without hijacking, dismiss/snooze feel. Follows the non-intrusive popup fix (#21)."
+```
+Record the two issue URLs in the PR description.
+
+---
+
+## Definition of done
+
+- `dfyb/macos_window.py` exists (dispatcher + macOS impl + isolated `_find_nswindow`), unit-tested for the no-op/fallback path.
+- `CountdownPopup` shows via `make_nonintrusive` (no `focus_force`); `_prevent_focus_steal` / `_get_frontmost_app` / `_previous_app` removed; `grep` finds no stray references.
+- `pytest -q` passes (expected **79**).
+- **Human live gates passed** on a dual-monitor + fullscreen setup: popup on the active Space, second monitor's Space untouched, foreground keeps focus, Done/Snooze usable, close doesn't switch Spaces.
+- Convention recorded in `CLAUDE.md` + committed `docs/conventions.md`.
+- Roadmap note added; both follow-up issues filed.
+
+## Wrap-up
+
+- Push: `git push -u origin popup-nonintrusive`.
+- Open a PR (base `main`) with `GH_CONFIG_DIR="$HOME/.config/gh-personal" gh pr create`. Include the two follow-up issue URLs. Verify CI (79 tests).
+
+## Known limitations carried forward
+
+- `_find_nswindow` matches by window title; if two on-screen windows share a title the first match wins. Acceptable for the break popup (unique title); revisit if it proves fragile.
+- First-click-on-Done may activate the app before the button press (accepted per spec); only address with `acceptsFirstMouse` handling if it proves annoying.

--- a/docs/specs/2026-06-11-roadmap-design.md
+++ b/docs/specs/2026-06-11-roadmap-design.md
@@ -145,8 +145,9 @@ Each phase maps to a **GitHub Milestone**; bullets become **issues**.
 - **Simplify main UI** — move settings behind a Settings button (#5).
 - Zero-config sensible defaults; anti-nag gentleness tuning.
 - Polish sweep: animation, sound design, visuals.
+- **Break presentation & barge-in UX** — entrance animation, how the popup grabs attention without hijacking focus (zero-focus-grab), where it appears on multi-monitor, dismiss/snooze feel. (Follows the non-intrusive popup fix, issue #21.)
 
-**Threaded principle:** every phase's definition-of-done includes "feels calm and gets out of the way." Phase 4 is the dedicated craft pass, not the only one.
+**Threaded principle:** every phase's definition-of-done includes "feels calm and gets out of the way." Phase 4 is the dedicated craft pass, not the only one. **Behaviors should be configurable** — user-facing behaviors (e.g. whether breaks defer during fullscreen) are preferences with sensible defaults, not hardcoded policy.
 
 ---
 

--- a/launch.py
+++ b/launch.py
@@ -29,6 +29,7 @@ from dfyb.activity.sensors import read_context
 from dfyb.scheduler.adapter import states_from_configs
 from dfyb.scheduler.tick import advance
 from dfyb.timer_lifecycle import timer_should_continue
+from dfyb.macos_window import pin_to_active_space
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -204,12 +205,13 @@ class CountdownPopup:
         self.snoozed = False
         self.sound_stop_event = threading.Event()
         self._start_time = time.time()  # For smooth progress bar
-        self._previous_app = self._get_frontmost_app()  # Remember active app
-
         # Create popup window
         self.window = ctk.CTkToplevel(parent)
         self.window.title(title)
         self.window.resizable(False, False)
+        # Pin the popup to the active Space (multi-monitor #21 fix): it appears
+        # on the Space you're on instead of switching to another.
+        pin_to_active_space(self.window)
 
         # Make window always on top
         self.window.attributes('-topmost', True)
@@ -229,7 +231,8 @@ class CountdownPopup:
         if sys.platform == "darwin":
             self.window.attributes('-alpha', 0.95)
 
-        # Force focus and request attention
+        # Reliably raise the popup and take focus (like a normal alert); it is
+        # pinned to the active Space above, so activating it won't switch Spaces.
         self.window.lift()
         self.window.focus_force()
         self._request_attention()
@@ -381,10 +384,8 @@ class CountdownPopup:
             self.window.withdraw()
         except Exception:
             pass
-        self._prevent_focus_steal()  # Call before destroy
         self.window.destroy()
         self.closed = True
-        self._prevent_focus_steal()  # Call after destroy
 
     def close(self):
         if self.closed:
@@ -397,41 +398,7 @@ class CountdownPopup:
             self.window.withdraw()
         except Exception:
             pass
-        self._prevent_focus_steal()  # Call before destroy to prevent focus transfer
         self.window.destroy()
-        self._prevent_focus_steal()  # Call again after to ensure app is deactivated
-
-    def _get_frontmost_app(self):
-        """Get the name of the currently frontmost application."""
-        if sys.platform != "darwin":
-            return None
-        try:
-            result = subprocess.run(
-                ['osascript', '-e',
-                 'tell application "System Events" to get name of first process whose frontmost is true'],
-                capture_output=True, text=True, timeout=2
-            )
-            return result.stdout.strip() if result.returncode == 0 else None
-        except Exception:
-            return None
-
-    def _prevent_focus_steal(self):
-        """Prevent main window from stealing focus and triggering Space switch on macOS."""
-        if sys.platform == "darwin":
-            try:
-                # Lower the parent window
-                self.parent.lower()
-                # Reactivate the app that was active before the popup appeared
-                if self._previous_app and self._previous_app != "Python":
-                    subprocess.run(
-                        ['osascript', '-e',
-                         f'tell application "{self._previous_app}" to activate'],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        timeout=2
-                    )
-            except Exception:
-                pass
 
     def _request_attention(self):
         """Request user attention."""
@@ -463,7 +430,6 @@ class CountdownPopup:
             y = mouse_y - popup_h // 2 + 20
             self.window.geometry(f"{popup_w}x{popup_h}+{x}+{y}")
             self.window.lift()
-            self.window.focus_force()
             self.window.attributes('-topmost', True)
         except Exception:
             pass
@@ -472,7 +438,6 @@ class CountdownPopup:
         """Bring popup to user's attention when countdown ends."""
         try:
             self.window.lift()
-            self.window.focus_force()
             self.window.attributes('-topmost', True)
             self._flash_button()
         except Exception:

--- a/tests/test_macos_window.py
+++ b/tests/test_macos_window.py
@@ -1,13 +1,13 @@
 import dfyb.macos_window as macos_window
 
 
-def test_make_nonintrusive_is_noop_off_macos(monkeypatch):
+def test_pin_to_active_space_is_noop_off_macos(monkeypatch):
     monkeypatch.setattr(macos_window.sys, "platform", "linux")
     # Must not touch the window and must not raise on non-macOS.
-    macos_window.make_nonintrusive(object())
+    macos_window.pin_to_active_space(object())
 
 
-def test_make_nonintrusive_swallows_failure_on_darwin(monkeypatch):
+def test_pin_to_active_space_swallows_failure_on_darwin(monkeypatch):
     monkeypatch.setattr(macos_window.sys, "platform", "darwin")
-    # A bad window (no .title()) / missing AppKit must be caught -> no raise.
-    macos_window.make_nonintrusive(object())
+    # A bad window (no .bind()) / missing AppKit must be caught -> no raise.
+    macos_window.pin_to_active_space(object())

--- a/tests/test_macos_window.py
+++ b/tests/test_macos_window.py
@@ -1,0 +1,13 @@
+import dfyb.macos_window as macos_window
+
+
+def test_make_nonintrusive_is_noop_off_macos(monkeypatch):
+    monkeypatch.setattr(macos_window.sys, "platform", "linux")
+    # Must not touch the window and must not raise on non-macOS.
+    macos_window.make_nonintrusive(object())
+
+
+def test_make_nonintrusive_swallows_failure_on_darwin(monkeypatch):
+    monkeypatch.setattr(macos_window.sys, "platform", "darwin")
+    # A bad window (no .title()) / missing AppKit must be caught -> no raise.
+    macos_window.make_nonintrusive(object())


### PR DESCRIPTION
## Fix #21 — break popup no longer switches Spaces on multi-monitor

On a dual-monitor Mac, the break popup used to **switch the other monitor away from its Space** and steal focus, because it activated the app (`focus_force`) and its close handler ran an AppleScript `tell app "X" to activate` (which jumps to that app's Space).

### What changed
- **New `dfyb/macos_window.py`** — `pin_to_active_space(window)`: a platform-guarded, best-effort helper that binds `<Map>` and sets the popup's `NSWindow` to `canJoinAllSpaces | fullScreenAuxiliary | stationary` at `NSStatusWindowLevel`, so it appears on the **active Space without switching**. macOS-only; a documented no-op with a named seam for Windows/Linux.
- **`CountdownPopup`** — retires the old `_prevent_focus_steal` / `_get_frontmost_app` / `_previous_app` AppleScript machinery (the Space-switcher) and pins the popup to the active Space. It still raises + takes focus like a normal alert so it reliably appears.
- **Conventions** — `docs/conventions.md` (+ CLAUDE.md): platform-specific-change rule (fallback + document gap + named seam) and a **configurability** principle (user-facing behaviors are prefs, not hardcoded).
- **Roadmap** — note for break-presentation / barge-in UX (Phase 4).

### Outcome (honest scope note)
The design goal was a fully non-intrusive "zero focus grab" popup. A deep spike (source-confirmed) established that Tk on macOS **force-activates the app** when it maps a window, and the APIs to hand focus back without a Space switch are regressed on modern macOS — so zero-grab needs a bigger rework. Per the spec's "don't let it become a sink" clause, this PR lands the **real bug fix** (no Space switch) with the popup reliably visible and taking focus like an alert; zero-grab is deferred.

### Testing
- `pytest -q`: **79 passed** (2 new pure tests for the platform-dispatch/no-op path; the rest is macOS window side-effects, verified live).
- Live-verified on dual-monitor: popup **visible** at cursor, other monitor's **Space stays put**, Done/Snooze work.

### Follow-ups filed
- #23 — fullscreen deferral inconsistent on multi-monitor (depends on dfyb window visibility) [bug]
- #24 — make "defer breaks during fullscreen" configurable [enhancement]
- #25 — popup presentation follow-ups: focus grab, hidden-behind-fullscreen, cursor placement [enhancement]

Closes #21.
