### PR TITLE
Coordinate scheduler idle thresholds + configurable away/rest lines (#80)

### DIFF
--- a/dfyb/insights/status.py
+++ b/dfyb/insights/status.py
@@ -32,6 +32,9 @@ HELD_LABELS = {
     "active": ("you're busy", "during activity"),
 }
 
+RESTED_HEADLINE = "Welcome back"
+RESTED_SUBTEXT = "That counted as a break — timers reset"
+
 
 @dataclass
 class StatusView:
@@ -45,7 +48,7 @@ class StatusView:
 
 
 def compute_status(*, running, paused, held_reason, next_name,
-                   next_remaining, next_interval, break_active):
+                   next_remaining, next_interval, break_active, just_rested=False):
     """Derive the hero view from app state. Order matters: idle → paused →
     holding → break → on-track. Paused keeps the countdown visible (the pill
     carries the 'Paused' state) and freezes the bar in grey; on-track/holding
@@ -67,6 +70,10 @@ def compute_status(*, running, paused, held_reason, next_name,
             chip=f"Breaks pause {tail}", progress_style="live")
     if break_active:
         return StatusView("break", "warning", "Break time", next_name, 1.0)
+    if just_rested:
+        return StatusView(
+            "on_track", "good", RESTED_HEADLINE, RESTED_SUBTEXT,
+            progress_fraction(next_remaining, next_interval), progress_style="live")
     return StatusView(
         "on_track", "good", f"Next break in {format_countdown(next_remaining)}",
         next_name, progress_fraction(next_remaining, next_interval),

--- a/dfyb/scheduler/engine.py
+++ b/dfyb/scheduler/engine.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 # Configurable thresholds (can surface to a settings UI in a later phase).
 NATURAL_BREAK_IDLE_THRESHOLD_SECONDS = 300  # idle >= this => natural break (reset all timers)
 AWAY_IDLE_THRESHOLD_SECONDS = 60            # idle >= this at fire time => defer (briefly away)
+MIN_LADDER_GAP_SECONDS = 5                  # strict-ordering floor between pause < away < natural
 
 FIRE = "fire"
 DEFER = "defer"
@@ -38,6 +39,17 @@ class StepResult:
 def is_natural_break(idle_seconds, threshold=NATURAL_BREAK_IDLE_THRESHOLD_SECONDS):
     """True if the user has been idle long enough to count as having taken a break."""
     return idle_seconds >= threshold
+
+
+def coordinate_thresholds(pause, away, natural, gap=MIN_LADDER_GAP_SECONDS):
+    """Return (pause, away, natural) guaranteed strictly ordered pause < away <
+    natural, anchored on `pause` (the user's explicit wait-until-you-pause value);
+    the upper rungs are floored up by `gap` as needed. Idempotent — coordinating an
+    already-ordered triple is a no-op. Pure; the safety net that makes the
+    'set pause >= away => break never fires' edge bug impossible for ANY config."""
+    away = max(away, pause + gap)
+    natural = max(natural, away + gap)
+    return pause, away, natural
 
 
 def decide(ctx, away_threshold=AWAY_IDLE_THRESHOLD_SECONDS, pause_threshold=0):

--- a/dfyb/scheduler/engine.py
+++ b/dfyb/scheduler/engine.py
@@ -73,8 +73,12 @@ def step(states, ctx,
          pause_threshold=0):
     """Advance one 1-second tick. Returns a StepResult describing what to do.
 
-    `states` is a list[BreakState] parallel to the app's break configs.
+    `states` is a list[BreakState] parallel to the app's break configs. Thresholds
+    are coordinated (pause < away < natural) up front, so the decision is coherent
+    for ANY caller-supplied values (incl. legacy / hand-edited prefs).
     """
+    pause_threshold, away_threshold, natural_threshold = coordinate_thresholds(
+        pause_threshold, away_threshold, natural_threshold)
     # 1. Natural break: idle long enough -> reset all timers, do not decrement.
     if is_natural_break(ctx.idle_seconds, natural_threshold):
         return StepResult(new_remaining=[s.interval_seconds for s in states],

--- a/dfyb/scheduler/tick.py
+++ b/dfyb/scheduler/tick.py
@@ -4,7 +4,8 @@ Pure (no Tk, no I/O). The timer loop calls `advance` once per tick and applies
 the returned new_remaining / fire_index / events.
 """
 from dfyb.activity.event_log import BREAK_DEFERRED, NATURAL_BREAK
-from dfyb.scheduler.engine import step
+from dfyb.scheduler.engine import (step, AWAY_IDLE_THRESHOLD_SECONDS,
+                                   NATURAL_BREAK_IDLE_THRESHOLD_SECONDS)
 
 # Episode markers used to dedup sustained idle/defer logging.
 IDLE_EPISODE = "idle"
@@ -29,8 +30,11 @@ def events_for_tick(result, ctx, episode):
     return [], None
 
 
-def advance(states, ctx, episode, pause_threshold=0):
+def advance(states, ctx, episode, pause_threshold=0,
+            away_threshold=AWAY_IDLE_THRESHOLD_SECONDS,
+            natural_threshold=NATURAL_BREAK_IDLE_THRESHOLD_SECONDS):
     """Run one tick. Returns (new_remaining, fire_index, events, new_episode)."""
-    result = step(states, ctx, pause_threshold=pause_threshold)
+    result = step(states, ctx, natural_threshold=natural_threshold,
+                  away_threshold=away_threshold, pause_threshold=pause_threshold)
     events, new_episode = events_for_tick(result, ctx, episode)
     return result.new_remaining, result.fire_index, events, new_episode

--- a/launch.py
+++ b/launch.py
@@ -39,7 +39,7 @@ from dfyb.activity.event_log import (
 from dfyb.activity.sensors import read_context, frontmost_window_rect, smooth_fullscreen
 from dfyb.popup_placement import screen_for_point, center_on_screen, clamp_onscreen
 from dfyb.scheduler.adapter import states_from_configs
-from dfyb.scheduler.tick import advance
+from dfyb.scheduler.tick import advance, IDLE_EPISODE
 from dfyb.scheduler.engine import (decide, DEFER, coordinate_thresholds,
                                    AWAY_IDLE_THRESHOLD_SECONDS,
                                    NATURAL_BREAK_IDLE_THRESHOLD_SECONDS)
@@ -1182,6 +1182,7 @@ class BreakApp:
         self.event_log = EventLog(EVENTS_FILE)
         self._episode = None  # idle/deferred dedup marker for the smart-timing loop
         self._held = None      # reason the due break is currently held (transparency)
+        self._rested_ack_until = None  # time.time() until which to show "welcome back"
         self._fullscreen_grace = 0  # ticks of fullscreen hysteresis left (#46)
         self._debounce_after = {}   # key -> pending after-id for debounced commits (#47)
         self._timer_generation = 0  # bumped each start(); stale threads exit
@@ -2198,9 +2199,13 @@ class BreakApp:
                 ctx = dataclass_replace(ctx, is_fullscreen=effective_fullscreen)
                 states = states_from_configs(self.breaks)
                 pause, away, natural = self._scheduler_thresholds()
+                prev_episode = self._episode
                 new_remaining, fire_index, events, self._episode = advance(
                     states, ctx, self._episode, pause_threshold=pause,
                     away_threshold=away, natural_threshold=natural)
+                if prev_episode == IDLE_EPISODE and self._episode != IDLE_EPISODE:
+                    # user just returned from a rest that reset the timers
+                    self._rested_ack_until = time.time() + NATURAL_BREAK_ACK_SECONDS
                 for config, remaining in zip(self.breaks, new_remaining):
                     config.remaining = remaining
                 for event_type, data in events:
@@ -2645,10 +2650,13 @@ class BreakApp:
             next_name = nxt.name.get()
             next_remaining = max(0, nxt.remaining)
             next_interval = nxt.get_interval_seconds()
+        just_rested = (self._rested_ack_until is not None
+                       and time.time() < self._rested_ack_until)
         view = compute_status(
             running=self.running, paused=self.paused, held_reason=self._held,
             next_name=next_name, next_remaining=next_remaining,
-            next_interval=next_interval, break_active=self.active_popup is not None)
+            next_interval=next_interval, break_active=self.active_popup is not None,
+            just_rested=just_rested)
         self.status_dot.configure(fg_color=STATUS_DOT_COLORS[view.dot])
         self.status.configure(text=STATUS_STATE_LABELS[view.state],
                               text_color=COLORS['text_secondary'])

--- a/launch.py
+++ b/launch.py
@@ -40,7 +40,9 @@ from dfyb.activity.sensors import read_context, frontmost_window_rect, smooth_fu
 from dfyb.popup_placement import screen_for_point, center_on_screen, clamp_onscreen
 from dfyb.scheduler.adapter import states_from_configs
 from dfyb.scheduler.tick import advance
-from dfyb.scheduler.engine import decide, DEFER
+from dfyb.scheduler.engine import (decide, DEFER, coordinate_thresholds,
+                                   AWAY_IDLE_THRESHOLD_SECONDS,
+                                   NATURAL_BREAK_IDLE_THRESHOLD_SECONDS)
 from dfyb.scheduler.dedup import break_in_play
 from dfyb.timer_lifecycle import timer_should_continue
 from dfyb.macos_window import pin_to_active_space
@@ -269,6 +271,16 @@ POPUP_WIDTH = 380  # height fits content (see CountdownPopup._position_popup)
 ACTIVITY_PAUSE_MIN = 2
 ACTIVITY_PAUSE_MAX = 15
 ACTIVITY_PAUSE_DEFAULT = 2   # seconds of stillness before a due break fires
+# Away / natural-rest idle lines (sliders; ranges deliberately non-overlapping with
+# the pause range so the three can never fall out of order — pause<=15 < away 30..120
+# < natural 180..1800). Defaults reuse the engine's ladder constants.
+AWAY_IDLE_MIN_SECONDS = 30
+AWAY_IDLE_MAX_SECONDS = 120
+AWAY_IDLE_STEP_SECONDS = 5
+NATURAL_BREAK_MIN_SECONDS = 180
+NATURAL_BREAK_MAX_SECONDS = 1800
+NATURAL_BREAK_STEP_SECONDS = 60
+NATURAL_BREAK_ACK_SECONDS = 6   # how long the "welcome back" cue lingers
 SNOOZE_RECHECK_MS = 5000     # while a snoozed break is context-deferred, re-check this often
 CONFIG_COMMIT_DEBOUNCE_MS = 800  # wait this long after the last keystroke before applying a typed interval/duration
 OVER_BREAK_SUFFIX = "over your break"  # trails the +MM:SS over-breaking count-up
@@ -1223,6 +1235,13 @@ class BreakApp:
             value=self.saved_prefs.get("activity_pause_seconds", ACTIVITY_PAUSE_DEFAULT)
         )
         self.activity_pause_seconds.trace_add('write', self._save_preferences)
+        self.away_idle_seconds = ctk.IntVar(
+            value=self.saved_prefs.get("away_idle_seconds", AWAY_IDLE_THRESHOLD_SECONDS))
+        self.away_idle_seconds.trace_add('write', self._save_preferences)
+        self.natural_break_seconds = ctk.IntVar(
+            value=self.saved_prefs.get("natural_break_seconds",
+                                       NATURAL_BREAK_IDLE_THRESHOLD_SECONDS))
+        self.natural_break_seconds.trace_add('write', self._save_preferences)
         # Whether bare mouse movement counts as activity for wait-until-you-pause
         # (default off — typing/clicks/scroll count, cursor nudges don't) (#41).
         self.count_mouse_move = ctk.BooleanVar(
@@ -1534,6 +1553,8 @@ class BreakApp:
             "popup_placement": self.popup_placement.get(),
             "defer_while_active": self.defer_while_active.get(),
             "activity_pause_seconds": self.activity_pause_seconds.get(),
+            "away_idle_seconds": self.away_idle_seconds.get(),
+            "natural_break_seconds": self.natural_break_seconds.get(),
             "count_mouse_move": self.count_mouse_move.get(),
             "snooze_seconds": self.snooze_seconds.get(),
             "last_update_check": self.saved_prefs.get("last_update_check", 0),
@@ -2141,11 +2162,10 @@ class BreakApp:
                     ctx.is_fullscreen, self._fullscreen_grace)
                 ctx = dataclass_replace(ctx, is_fullscreen=effective_fullscreen)
                 states = states_from_configs(self.breaks)
-                pause = (self.activity_pause_seconds.get()
-                         if self.defer_while_active.get() else 0)
+                pause, away, natural = self._scheduler_thresholds()
                 new_remaining, fire_index, events, self._episode = advance(
-                    states, ctx, self._episode, pause_threshold=pause
-                )
+                    states, ctx, self._episode, pause_threshold=pause,
+                    away_threshold=away, natural_threshold=natural)
                 for config, remaining in zip(self.breaks, new_remaining):
                     config.remaining = remaining
                 for event_type, data in events:
@@ -2164,6 +2184,14 @@ class BreakApp:
                     self.trigger_break(self.breaks[fire_index], held_reason=held_reason)
             except Exception as e:
                 logging.error(f"timer_loop tick failed: {e}", exc_info=True)
+
+    def _scheduler_thresholds(self):
+        """Coordinated (pause, away, natural) idle thresholds from prefs — the one
+        source of truth for both the timer loop and the snooze-hold check."""
+        pause = (self.activity_pause_seconds.get()
+                 if self.defer_while_active.get() else 0)
+        return coordinate_thresholds(pause, self.away_idle_seconds.get(),
+                                     self.natural_break_seconds.get())
 
     def _capture_active_screen(self):
         """Screen (x, y, w, h) the user is working on, captured BEFORE the popup
@@ -2312,9 +2340,10 @@ class BreakApp:
             check_fullscreen=self.defer_during_fullscreen.get(),
             count_mouse_move=self.count_mouse_move.get(),
         )
-        pause = (self.activity_pause_seconds.get()
-                 if self.defer_while_active.get() else 0)
-        if should_hold_snooze(self.paused, decide(ctx, pause_threshold=pause) == DEFER):
+        pause, away, _natural = self._scheduler_thresholds()
+        if should_hold_snooze(self.paused,
+                              decide(ctx, away_threshold=away,
+                                     pause_threshold=pause) == DEFER):
             # Not a good moment (paused or context-deferred) — wait and re-check.
             logging.info("snoozed break held (paused=%s fullscreen=%s meeting=%s), re-checking",
                          self.paused, ctx.is_fullscreen, ctx.is_meeting)

--- a/launch.py
+++ b/launch.py
@@ -1975,6 +1975,21 @@ class BreakApp:
             number_of_steps=ACTIVITY_PAUSE_MAX - ACTIVITY_PAUSE_MIN, command=_on_pause)
         self._pause_slider.set(self.activity_pause_seconds.get())
         self._pause_slider.pack(side="right")
+
+        # Away & rest timing — always-on lines (independent of wait-until-you-pause).
+        ctk.CTkLabel(smart.body, text="Away & rest timing", font=make_font('caption'),
+                     text_color=COLORS['text_tertiary']).pack(
+            anchor="w", padx=PADDING_PANEL_X, pady=(SPACE_SM, SPACE_XXS))
+        timing = ctk.CTkFrame(smart.body, fg_color="transparent")
+        timing.pack(fill="x", anchor="w", padx=PADDING_PANEL_X, pady=(0, PADDING_PANEL_Y))
+        self._build_timing_slider(
+            timing, self.away_idle_seconds,
+            lambda v: f"Consider you away after: {v} sec",
+            AWAY_IDLE_MIN_SECONDS, AWAY_IDLE_MAX_SECONDS, AWAY_IDLE_STEP_SECONDS)
+        self._build_timing_slider(
+            timing, self.natural_break_seconds,
+            lambda v: f"Count as a rest after: {v // 60} min",
+            NATURAL_BREAK_MIN_SECONDS, NATURAL_BREAK_MAX_SECONDS, NATURAL_BREAK_STEP_SECONDS)
         smart.finalize()
 
         # Grey out the sub-options live when "Wait until you pause" is off.
@@ -2040,6 +2055,26 @@ class BreakApp:
             if panel.config is config:
                 panel.focus_config()
                 break
+
+    def _build_timing_slider(self, parent, var, label_fn, lo, hi, step):
+        """A labeled slider row (label left, slider right) that writes `var` and
+        updates its label live via label_fn(value). Mirrors the Pause-length control
+        for the always-on away/rest lines."""
+        row = ctk.CTkFrame(parent, fg_color="transparent")
+        row.pack(anchor="w", fill="x", pady=(SPACE_XS, 0))
+        var.set(max(lo, min(hi, var.get())))   # heal an out-of-range stored value
+        label = ctk.CTkLabel(row, text=label_fn(var.get()), font=make_font('label'))
+        label.pack(side="left")
+
+        def _on(value):
+            v = int(round(value / step) * step)
+            var.set(v)
+            label.configure(text=label_fn(v))
+
+        slider = ctk.CTkSlider(row, from_=lo, to=hi,
+                               number_of_steps=(hi - lo) // step, command=_on)
+        slider.set(var.get())
+        slider.pack(side="right")
 
     def _sync_activity_suboptions(self, *args):
         """Enable/grey the 'wait until you pause' sub-options to match the parent."""

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -1,6 +1,9 @@
 from dfyb.scheduler.engine import (
     Context, BreakState, step, decide, is_natural_break, FIRE, DEFER,
+    coordinate_thresholds, MIN_LADDER_GAP_SECONDS,
 )
+
+GAP = MIN_LADDER_GAP_SECONDS
 
 
 def ctx(idle=0.0, fullscreen=False):
@@ -221,3 +224,28 @@ def test_decide_away_ignores_active_idle():
     # away keys off idle_seconds (any input) regardless of active_idle
     ctx = Context(idle_seconds=100, is_fullscreen=False, active_idle_seconds=0)
     assert decide(ctx, pause_threshold=2) == DEFER
+
+
+# --- coordinate_thresholds (Task 1) ---------------------------------------
+
+def test_coordinate_keeps_already_ordered_values():
+    assert coordinate_thresholds(2, 60, 300) == (2, 60, 300)
+    assert coordinate_thresholds(0, 60, 300) == (0, 60, 300)
+
+
+def test_coordinate_floors_away_above_pause():
+    assert coordinate_thresholds(90, 60, 300) == (90, 90 + GAP, 300)
+
+
+def test_coordinate_floors_natural_above_away():
+    # away floored above pause, then natural floored above that
+    assert coordinate_thresholds(90, 60, 90) == (90, 90 + GAP, 90 + 2 * GAP)
+
+
+def test_coordinate_all_equal_gets_gapped():
+    assert coordinate_thresholds(50, 50, 50) == (50, 50 + GAP, 50 + 2 * GAP)
+
+
+def test_coordinate_is_idempotent():
+    once = coordinate_thresholds(90, 60, 90)
+    assert coordinate_thresholds(*once) == once

--- a/tests/test_scheduler_engine.py
+++ b/tests/test_scheduler_engine.py
@@ -249,3 +249,43 @@ def test_coordinate_all_equal_gets_gapped():
 def test_coordinate_is_idempotent():
     once = coordinate_thresholds(90, 60, 90)
     assert coordinate_thresholds(*once) == once
+
+
+# --- step() honors coordinated thresholds (Task 2) -------------------------
+
+def _due_states():
+    # one break that becomes due this tick (remaining 1 -> 0)
+    return [BreakState(remaining=1, interval_seconds=1500, duration_seconds=300)]
+
+
+def test_regression_pause_ge_away_still_fires_when_present():
+    # pause 90 >= away 60: previously "away" defers at 60 before active_idle hits
+    # 90, so a still pause could NEVER fire. Coordination floors away to 95, so a
+    # present-and-paused user (idle 92 in [90,95)) fires.
+    ctx = Context(idle_seconds=92, is_fullscreen=False, active_idle_seconds=92)
+    res = step(_due_states(), ctx, natural_threshold=300,
+               away_threshold=60, pause_threshold=90)
+    assert res.fire_index == 0
+    assert res.defer_reason is None
+
+
+def test_gone_past_configured_away_defers_away():
+    ctx = Context(idle_seconds=96, is_fullscreen=False, active_idle_seconds=96)
+    res = step(_due_states(), ctx, natural_threshold=300,
+               away_threshold=60, pause_threshold=90)  # coordinated away = 95
+    assert res.fire_index is None
+    assert res.defer_reason == "away"
+
+
+def test_present_pause_never_labelled_away():
+    # stopped typing but moving the mouse: present (idle low) + paused -> FIRE
+    ctx = Context(idle_seconds=1, is_fullscreen=False, active_idle_seconds=10)
+    res = step(_due_states(), ctx, away_threshold=60, pause_threshold=3)
+    assert res.fire_index == 0
+
+
+def test_configured_natural_threshold_resets_timers():
+    ctx = Context(idle_seconds=200, is_fullscreen=False, active_idle_seconds=200)
+    res = step(_due_states(), ctx, natural_threshold=180)  # 200 >= 180
+    assert res.natural_break is True
+    assert res.new_remaining == [1500]

--- a/tests/test_scheduler_tick.py
+++ b/tests/test_scheduler_tick.py
@@ -102,3 +102,24 @@ def test_advance_defers_active():
     assert fire_index is None
     assert events == [(BREAK_DEFERRED, {"reason": "active"})]
     assert ep == DEFERRED_EPISODE
+
+
+# --- advance forwards away/natural thresholds (Task 3) ---------------------
+
+def _due_states():
+    return [BreakState(remaining=1, interval_seconds=1500, duration_seconds=300)]
+
+
+def test_advance_forwards_away_threshold():
+    c = Context(idle_seconds=40, is_fullscreen=False, active_idle_seconds=40)
+    # pause off (0): a due break fires when present (idle < away), defers when away.
+    _, fire_lo, _, _ = advance(_due_states(), c, None, pause_threshold=0, away_threshold=30)
+    _, fire_hi, _, _ = advance(_due_states(), c, None, pause_threshold=0, away_threshold=60)
+    assert fire_lo is None      # idle 40 >= away 30 -> defer away
+    assert fire_hi == 0         # idle 40 < away 60 -> fire
+
+
+def test_advance_forwards_natural_threshold():
+    c = Context(idle_seconds=200, is_fullscreen=False, active_idle_seconds=200)
+    _, _, _, ep = advance(_due_states(), c, None, natural_threshold=180)
+    assert ep == IDLE_EPISODE    # 200 >= 180 -> natural break episode

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,4 +1,5 @@
-from dfyb.insights.status import format_countdown, progress_fraction, compute_status
+from dfyb.insights.status import (format_countdown, progress_fraction, compute_status,
+                                  RESTED_HEADLINE, RESTED_SUBTEXT)
 
 
 class TestFormat:
@@ -70,3 +71,37 @@ class TestCompute:
     def test_holding_unknown_reason_falls_back(self):
         v = compute_status(**self.base(held_reason="thing"))
         assert v.headline == "Waiting — thing" and v.chip == "Breaks pause during thing"
+
+
+# --- welcome-back cue (Task 4) ---------------------------------------------
+
+_BASE = dict(next_name="Micro Break", next_remaining=100, next_interval=200)
+
+
+def test_just_rested_shows_welcome_back_on_track():
+    v = compute_status(running=True, paused=False, held_reason=None,
+                       break_active=False, just_rested=True, **_BASE)
+    assert v.headline == RESTED_HEADLINE
+    assert v.subtext == RESTED_SUBTEXT
+    assert v.state == "on_track" and v.dot == "good"
+
+
+def test_just_rested_ignored_when_paused():
+    v = compute_status(running=True, paused=True, held_reason=None,
+                       break_active=False, just_rested=True, **_BASE)
+    assert v.state == "paused"
+
+
+def test_just_rested_ignored_when_holding_or_break():
+    held = compute_status(running=True, paused=False, held_reason="away",
+                          break_active=False, just_rested=True, **_BASE)
+    brk = compute_status(running=True, paused=False, held_reason=None,
+                         break_active=True, just_rested=True, **_BASE)
+    assert held.state == "holding"
+    assert brk.state == "break"
+
+
+def test_default_just_rested_is_backward_compatible():
+    v = compute_status(running=True, paused=False, held_reason=None,
+                       break_active=False, **_BASE)
+    assert v.state == "on_track" and v.headline.startswith("Next break")


### PR DESCRIPTION
Fixes #80.

## Problem
The scheduler's three idle thresholds (pause / away / natural-break) weren't coordinated. Setting the "wait until you pause" length ≥ the away line (60s) meant a break due during a still pause could **never fire**, and the "you're away" vs "waiting for a pause" messaging could contradict.

## Changes
- **`coordinate_thresholds()`** (pure, engine) — guarantees `pause < away < natural` (anchored on pause); idempotent safety net that makes the "never fires" edge bug impossible for any config.
- **`step()`** coordinates its thresholds up front; **`advance()`** forwards `away`/`natural` from prefs.
- **Configurable away / natural** — two backward-compatible prefs (`away_idle_seconds`=60, `natural_break_seconds`=300) surfaced as "Away & rest timing" sliders under Smart pausing. Slider ranges are non-overlapping with the pause range, so the sliders can never fall out of order.
- **Welcome-back cue** — when a natural rest silently resets the timers and you return, the hero briefly shows "Welcome back — that counted as a break, timers reset".
- `_scheduler_thresholds()` is the single source of truth for the timer loop and the snooze-hold check.

## Testing
- 15 new pure unit tests (coordination, the `pause ≥ away` regression, ladder zones with configured thresholds, present-pause-never-away, welcome-back view). Full suite: **255 passed**.
- Tk pieces verified with Quartz captures: both sliders render with correct defaults; the welcome-back hero renders and reverts on expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
